### PR TITLE
Add proto generation tooling and schema for agents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 cpp-service/data_service
 python-worker/__pycache__
 rust-agent/target
+cpp-service/generated/
+python-worker/*_pb2.py

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build test
 
-build: ; g++ -std=c++17 cpp-service/DataService.cpp -o cpp-service/data_service && cargo build --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py
+build: ; ./scripts/gen-protos.sh && g++ -std=c++17 cpp-service/DataService.cpp -o cpp-service/data_service && cargo build --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py
 
-test: ; cargo test --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py
+test: ; ./scripts/gen-protos.sh && cargo test --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -10,3 +10,30 @@ message UpdateUserResponse {
   bool success = 1;
   string message = 2;
 }
+
+message UpdateUserEvent {
+  int32 user_id = 1;
+  string field = 2;
+  string old_value = 3;
+  string new_value = 4;
+}
+
+message GetUserRequest {
+  int32 user_id = 1;
+}
+
+message GetUserResponse {
+  int32 user_id = 1;
+  string name = 2;
+  int32 age = 3;
+}
+
+message SensorData {
+  string sensor_id = 1;
+  double value = 2;
+}
+
+message ControlCommand {
+  string target = 1;
+  string command = 2;
+}

--- a/rust-agent/Cargo.toml
+++ b/rust-agent/Cargo.toml
@@ -2,5 +2,10 @@
 name = "rust-agent"
 version = "0.1.0"
 edition = "2024"
+build = "build.rs"
 
 [dependencies]
+prost = "0.12"
+
+[build-dependencies]
+prost-build = "0.12"

--- a/rust-agent/build.rs
+++ b/rust-agent/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    let proto_file = "../proto/data.proto";
+    println!("cargo:rerun-if-changed={}", proto_file);
+    prost_build::compile_protos(&[proto_file], &["../proto"]).expect("Failed to compile protos");
+}

--- a/rust-agent/src/main.rs
+++ b/rust-agent/src/main.rs
@@ -1,11 +1,18 @@
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/data.rs"));
+}
+
 fn main() {
     println!("Rust agent ready");
 }
 
 #[cfg(test)]
 mod tests {
+    use super::proto::GetUserRequest;
+
     #[test]
     fn it_runs() {
+        let _req = GetUserRequest { user_id: 1 };
         assert_eq!(2 + 2, 4);
     }
 }

--- a/scripts/gen-protos.sh
+++ b/scripts/gen-protos.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROTO_DIR="$SCRIPT_DIR/../proto"
+CPP_OUT="$SCRIPT_DIR/../cpp-service/generated"
+PY_OUT="$SCRIPT_DIR/../python-worker"
+
+mkdir -p "$CPP_OUT"
+protoc -I"$PROTO_DIR" --cpp_out="$CPP_OUT" "$PROTO_DIR/data.proto"
+protoc -I"$PROTO_DIR" --python_out="$PY_OUT" "$PROTO_DIR/data.proto"
+# Rust code is generated via build.rs during cargo build


### PR DESCRIPTION
## Summary
- expand `data.proto` with user and sensor/control messages
- add `gen-protos.sh` to compile proto files for C++, Python, and Rust
- wire generation into Makefile and Rust build

## Testing
- `./scripts/gen-protos.sh`
- `make test` *(fails: failed to download crates: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `python -m py_compile python-worker/worker.py`


------
https://chatgpt.com/codex/tasks/task_e_689d6229cd8c832aa8d71885794c1e6a