### PR TITLE
Add ZeroMQ data service with cache and SQLite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cpp-service/data_service
 python-worker/__pycache__
 rust-agent/target
+build/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,13 @@
 .PHONY: build test
 
-build: ; g++ -std=c++17 cpp-service/DataService.cpp -o cpp-service/data_service && cargo build --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py
+build:
+	cmake -S cpp-service -B build/cpp-service
+	cmake --build build/cpp-service
+	cargo build --manifest-path rust-agent/Cargo.toml
+	python -m py_compile python-worker/worker.py
 
-test: ; cargo test --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py
+test:
+	cmake -S cpp-service -B build/cpp-service
+	cmake --build build/cpp-service
+	cargo test --manifest-path rust-agent/Cargo.toml
+	python -m py_compile python-worker/worker.py

--- a/cpp-service/CMakeLists.txt
+++ b/cpp-service/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.15)
+project(data_service)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(Protobuf REQUIRED)
+include_directories(${Protobuf_INCLUDE_DIRS})
+
+protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../proto/data.proto)
+
+add_executable(data_service DataService.cpp Cache.cpp Database.cpp ${PROTO_SRCS})
+
+target_include_directories(data_service PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+
+target_link_libraries(data_service PRIVATE protobuf::libprotobuf sqlite3 zmq)

--- a/cpp-service/Cache.cpp
+++ b/cpp-service/Cache.cpp
@@ -1,0 +1,17 @@
+#include "Cache.h"
+
+std::string Cache::Get(int userId, const std::string& field) {
+    auto userIt = data_.find(userId);
+    if (userIt == data_.end()) {
+        return "";
+    }
+    auto fieldIt = userIt->second.find(field);
+    if (fieldIt == userIt->second.end()) {
+        return "";
+    }
+    return fieldIt->second;
+}
+
+void Cache::Set(int userId, const std::string& field, const std::string& value) {
+    data_[userId][field] = value;
+}

--- a/cpp-service/Cache.h
+++ b/cpp-service/Cache.h
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+class Cache {
+public:
+    std::string Get(int userId, const std::string& field);
+    void Set(int userId, const std::string& field, const std::string& value);
+private:
+    std::unordered_map<int, std::unordered_map<std::string, std::string>> data_;
+};

--- a/cpp-service/DataService.cpp
+++ b/cpp-service/DataService.cpp
@@ -1,6 +1,75 @@
 #include <iostream>
+#include <string>
+#include <zmq.hpp>
+#include "Cache.h"
+#include "Database.h"
+#include "data.pb.h"
 
 int main() {
-    std::cout << "Data Service running" << std::endl;
+    Cache cache;
+    Database db("users.db", cache);
+
+    zmq::context_t context{1};
+    zmq::socket_t rep{context, zmq::socket_type::rep};
+    rep.bind("tcp://0.0.0.0:5555");
+    zmq::socket_t pub{context, zmq::socket_type::pub};
+    pub.bind("tcp://0.0.0.0:5556");
+
+    while (true) {
+        zmq::message_t typeMsg;
+        zmq::message_t dataMsg;
+        if (!rep.recv(typeMsg, zmq::recv_flags::none)) {
+            break;
+        }
+        if (!rep.recv(dataMsg, zmq::recv_flags::none)) {
+            break;
+        }
+        std::string type(static_cast<char*>(typeMsg.data()), typeMsg.size());
+
+        if (type == "UpdateUserRequest") {
+            UpdateUserRequest req;
+            req.ParseFromArray(dataMsg.data(), dataMsg.size());
+            bool success = db.UpdateUser(req.user_id(), req.field(), req.value());
+            UpdateUserResponse resp;
+            resp.set_success(success);
+            resp.set_message(success ? "updated" : "error");
+            std::string respStr;
+            resp.SerializeToString(&respStr);
+            rep.send(zmq::str_buffer("UpdateUserResponse"), zmq::send_flags::sndmore);
+            rep.send(zmq::buffer(respStr));
+
+            UpdateUserEvent ev;
+            ev.set_user_id(req.user_id());
+            ev.set_field(req.field());
+            ev.set_value(req.value());
+            std::string evStr;
+            ev.SerializeToString(&evStr);
+            pub.send(zmq::str_buffer("UpdateUserEvent"), zmq::send_flags::sndmore);
+            pub.send(zmq::buffer(evStr));
+        } else if (type == "GetUserRequest") {
+            GetUserRequest req;
+            req.ParseFromArray(dataMsg.data(), dataMsg.size());
+            GetUserResponse resp;
+            std::string value = db.GetUser(req.user_id(), req.field());
+            if (!value.empty()) {
+                resp.set_found(true);
+                resp.set_value(value);
+            } else {
+                resp.set_found(false);
+            }
+            std::string respStr;
+            resp.SerializeToString(&respStr);
+            rep.send(zmq::str_buffer("GetUserResponse"), zmq::send_flags::sndmore);
+            rep.send(zmq::buffer(respStr));
+        } else {
+            UpdateUserResponse resp;
+            resp.set_success(false);
+            resp.set_message("unknown request");
+            std::string respStr;
+            resp.SerializeToString(&respStr);
+            rep.send(zmq::str_buffer("UpdateUserResponse"), zmq::send_flags::sndmore);
+            rep.send(zmq::buffer(respStr));
+        }
+    }
     return 0;
 }

--- a/cpp-service/Database.cpp
+++ b/cpp-service/Database.cpp
@@ -1,0 +1,64 @@
+#include "Database.h"
+#include <iostream>
+
+Database::Database(const std::string& dbPath, Cache& cache) : db_(nullptr), cache_(cache) {
+    if (sqlite3_open(dbPath.c_str(), &db_) != SQLITE_OK) {
+        std::cerr << "Cannot open DB: " << sqlite3_errmsg(db_) << std::endl;
+    } else {
+        const char* sql = "CREATE TABLE IF NOT EXISTS users (user_id INTEGER, field TEXT, value TEXT, PRIMARY KEY(user_id, field));";
+        char* errMsg = nullptr;
+        if (sqlite3_exec(db_, sql, nullptr, nullptr, &errMsg) != SQLITE_OK) {
+            std::cerr << "Cannot create table: " << errMsg << std::endl;
+            sqlite3_free(errMsg);
+        }
+    }
+}
+
+Database::~Database() {
+    if (db_) {
+        sqlite3_close(db_);
+    }
+}
+
+bool Database::UpdateUser(int userId, const std::string& field, const std::string& value) {
+    const char* sql = "INSERT INTO users (user_id, field, value) VALUES (?,?,?) ON CONFLICT(user_id, field) DO UPDATE SET value=excluded.value;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        return false;
+    }
+    sqlite3_bind_int(stmt, 1, userId);
+    sqlite3_bind_text(stmt, 2, field.c_str(), -1, SQLITE_TRANSIENT);
+    sqlite3_bind_text(stmt, 3, value.c_str(), -1, SQLITE_TRANSIENT);
+    bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+    sqlite3_finalize(stmt);
+    if (ok) {
+        cache_.Set(userId, field, value);
+    }
+    return ok;
+}
+
+std::string Database::GetUser(int userId, const std::string& field) {
+    std::string cached = cache_.Get(userId, field);
+    if (!cached.empty()) {
+        return cached;
+    }
+    const char* sql = "SELECT value FROM users WHERE user_id=? AND field=?;";
+    sqlite3_stmt* stmt;
+    if (sqlite3_prepare_v2(db_, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+        return "";
+    }
+    sqlite3_bind_int(stmt, 1, userId);
+    sqlite3_bind_text(stmt, 2, field.c_str(), -1, SQLITE_TRANSIENT);
+    std::string value;
+    if (sqlite3_step(stmt) == SQLITE_ROW) {
+        const unsigned char* text = sqlite3_column_text(stmt, 0);
+        if (text) {
+            value = reinterpret_cast<const char*>(text);
+        }
+    }
+    sqlite3_finalize(stmt);
+    if (!value.empty()) {
+        cache_.Set(userId, field, value);
+    }
+    return value;
+}

--- a/cpp-service/Database.h
+++ b/cpp-service/Database.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+#include <sqlite3.h>
+#include "Cache.h"
+
+class Database {
+public:
+    Database(const std::string& dbPath, Cache& cache);
+    ~Database();
+
+    bool UpdateUser(int userId, const std::string& field, const std::string& value);
+    std::string GetUser(int userId, const std::string& field);
+
+private:
+    sqlite3* db_;
+    Cache& cache_;
+};

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -10,3 +10,19 @@ message UpdateUserResponse {
   bool success = 1;
   string message = 2;
 }
+
+message GetUserRequest {
+  int32 user_id = 1;
+  string field = 2;
+}
+
+message GetUserResponse {
+  bool found = 1;
+  string value = 2;
+}
+
+message UpdateUserEvent {
+  int32 user_id = 1;
+  string field = 2;
+  string value = 3;
+}


### PR DESCRIPTION
## Summary
- Expand protobuf schema with user update, query, and event messages
- Implement in-memory cache and SQLite database with write-through policy
- Add ZeroMQ REP/PUB service handling UpdateUser and GetUser requests
- Switch C++ service to CMake build system

## Testing
- `make build` *(fails: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR))*
- `apt-get update` *(fails: repository '... noble InRelease' is not signed)*
- `make test` *(fails: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR))*


------
https://chatgpt.com/codex/tasks/task_e_689d622bdd58832aac208d5ed21517c7