### PR TITLE
Integrate Protobuf and ZeroMQ in rust-agent

### DIFF
--- a/proto/data.proto
+++ b/proto/data.proto
@@ -10,3 +10,13 @@ message UpdateUserResponse {
   bool success = 1;
   string message = 2;
 }
+
+message SensorReading {
+  int32 sensor_id = 1;
+  double value = 2;
+  int64 timestamp = 3;
+}
+
+message ControlCommand {
+  uint64 new_rate = 1;
+}

--- a/rust-agent/Cargo.toml
+++ b/rust-agent/Cargo.toml
@@ -4,3 +4,8 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+prost = "0.12"
+zmq = "0.10"
+
+[build-dependencies]
+prost-build = "0.12"

--- a/rust-agent/build.rs
+++ b/rust-agent/build.rs
@@ -1,0 +1,4 @@
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    prost_build::compile_protos(&["../proto/data.proto"], &["../proto"])?;
+    Ok(())
+}

--- a/rust-agent/src/lib.rs
+++ b/rust-agent/src/lib.rs
@@ -1,0 +1,102 @@
+use prost::Message;
+use std::sync::{Arc, atomic::{AtomicU64, Ordering}};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+pub mod proto {
+    include!(concat!(env!("OUT_DIR"), "/data.rs"));
+}
+
+use proto::{SensorReading, ControlCommand};
+
+pub fn run() {
+    let context = zmq::Context::new();
+    let publisher = context.socket(zmq::PUB).expect("create pub socket");
+    publisher.bind("tcp://*:5555").expect("bind pub socket");
+
+    let subscriber = context.socket(zmq::SUB).expect("create sub socket");
+    subscriber
+        .connect("tcp://localhost:5556")
+        .expect("connect sub socket");
+    subscriber.set_subscribe(b"").expect("subscribe");
+
+    let rate = Arc::new(AtomicU64::new(1));
+    let rate_for_sub = rate.clone();
+
+    std::thread::spawn(move || {
+        loop {
+            if let Ok(bytes) = subscriber.recv_bytes(0) {
+                if let Ok(cmd) = ControlCommand::decode(&*bytes) {
+                    rate_for_sub.store(cmd.new_rate, Ordering::Relaxed);
+                }
+            }
+        }
+    });
+
+    loop {
+        let ts = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("time went backwards")
+            .as_secs() as i64;
+        let reading = SensorReading {
+            sensor_id: 1,
+            value: 0.0,
+            timestamp: ts,
+        };
+        let mut buf = Vec::new();
+        reading.encode(&mut buf).expect("encode");
+        publisher.send(buf, 0).expect("send");
+        let delay = rate.load(Ordering::Relaxed);
+        std::thread::sleep(Duration::from_secs(delay));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::proto::{ControlCommand, SensorReading};
+    use prost::Message;
+    use std::{thread, time::Duration};
+
+    #[test]
+    fn sensor_reading_roundtrip() {
+        let ctx = zmq::Context::new();
+        let pub_socket = ctx.socket(zmq::PUB).unwrap();
+        let sub_socket = ctx.socket(zmq::SUB).unwrap();
+        let endpoint = "inproc://sensor";
+        pub_socket.bind(endpoint).unwrap();
+        sub_socket.connect(endpoint).unwrap();
+        sub_socket.set_subscribe(b"").unwrap();
+
+        let reading = SensorReading { sensor_id: 7, value: 1.23, timestamp: 99 };
+        let mut buf = Vec::new();
+        reading.encode(&mut buf).unwrap();
+
+        thread::sleep(Duration::from_millis(50));
+        pub_socket.send(buf, 0).unwrap();
+
+        let bytes = sub_socket.recv_bytes(0).unwrap();
+        let decoded = SensorReading::decode(&*bytes).unwrap();
+        assert_eq!(reading, decoded);
+    }
+
+    #[test]
+    fn control_command_roundtrip() {
+        let ctx = zmq::Context::new();
+        let pub_socket = ctx.socket(zmq::PUB).unwrap();
+        let sub_socket = ctx.socket(zmq::SUB).unwrap();
+        let endpoint = "inproc://cmd";
+        pub_socket.bind(endpoint).unwrap();
+        sub_socket.connect(endpoint).unwrap();
+        sub_socket.set_subscribe(b"").unwrap();
+
+        let cmd = ControlCommand { new_rate: 5 };
+        let mut buf = Vec::new();
+        cmd.encode(&mut buf).unwrap();
+
+        thread::sleep(Duration::from_millis(50));
+        pub_socket.send(buf, 0).unwrap();
+
+        let bytes = sub_socket.recv_bytes(0).unwrap();
+        let decoded = ControlCommand::decode(&*bytes).unwrap();
+        assert_eq!(cmd, decoded);
+    }
+}

--- a/rust-agent/src/main.rs
+++ b/rust-agent/src/main.rs
@@ -1,11 +1,3 @@
 fn main() {
-    println!("Rust agent ready");
-}
-
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_runs() {
-        assert_eq!(2 + 2, 4);
-    }
+    rust_agent::run();
 }


### PR DESCRIPTION
## Summary
- Compile data.proto via prost-build and expose generated types
- Implement ZeroMQ publisher for SensorReading and subscriber for ControlCommand with adjustable rate
- Add tests verifying message serialization with in-process ZeroMQ sockets

## Testing
- `cargo test` *(fails: download of config.json failed: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*

------
https://chatgpt.com/codex/tasks/task_e_689d622eb244832a85f8a125a020bd6d