### PR TITLE
Set up cross-compilation build and CI

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[build]
+target = "aarch64-unknown-linux-gnu"
+
+[target.aarch64-unknown-linux-gnu]
+linker = "aarch64-linux-gnu-gcc"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      image: mcr.microsoft.com/devcontainers/base:ubuntu
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          apt-get update
+          apt-get install -y cmake protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip
+          rustup target add aarch64-unknown-linux-gnu
+          pip install pytest
+      - name: Build
+        run: make build
+      - name: Test
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,16 @@
+PROTO = proto/data.proto
+CPP_BUILD_DIR = build/cpp-service
+
 .PHONY: build test
 
-build: ; g++ -std=c++17 cpp-service/DataService.cpp -o cpp-service/data_service && cargo build --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py
+build:
+	protoc -I proto --cpp_out=cpp-service --python_out=python-worker $(PROTO)
+	cmake -S cpp-service -B $(CPP_BUILD_DIR)
+	cmake --build $(CPP_BUILD_DIR)
+	cargo build --target=aarch64-unknown-linux-gnu --manifest-path rust-agent/Cargo.toml
+	python -m py_compile python-worker/*.py
 
-test: ; cargo test --manifest-path rust-agent/Cargo.toml && python -m py_compile python-worker/worker.py
+test:
+	ctest --test-dir $(CPP_BUILD_DIR)
+	cargo test --target=aarch64-unknown-linux-gnu --manifest-path rust-agent/Cargo.toml
+	pytest || [ $$? -eq 5 ]

--- a/cpp-service/CMakeLists.txt
+++ b/cpp-service/CMakeLists.txt
@@ -1,0 +1,14 @@
+cmake_minimum_required(VERSION 3.16)
+project(cpp_service LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
+
+# Cross-compilation settings for ARM64
+set(CMAKE_SYSTEM_NAME Linux)
+set(CMAKE_SYSTEM_PROCESSOR aarch64)
+set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
+set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
+
+add_executable(data_service DataService.cpp)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,12 @@
+[project]
+name = "cross-compile"
+version = "0.1.0"
+requires-python = ">=3.10"
+dependencies = []
+
+[build-system]
+requires = ["setuptools"]
+build-backend = "setuptools.build_meta"
+
+[tool.black]
+line-length = 88


### PR DESCRIPTION
## Summary
- Add CMake cross-compilation setup for cpp-service exporting compile commands
- Configure Cargo for ARM64 builds and add Python `pyproject.toml`
- Replace Makefile with orchestrated build/test steps and add CI workflow

## Testing
- `make build` *(fails: aarch64-linux-gnu-g++: No such file or directory)*
- `make test` *(fails: can't find crate for `std`, target may not be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689d62304c60832ab4bab68a886316fb