### PR TITLE
Add integration test and benchmarking harness

### DIFF
--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,40 @@
+# Integration Testing and Benchmarking
+
+This document outlines how to bring up the cross-platform demo and run
+integration tests and benchmarks.
+
+## Prerequisites
+
+- `aarch64-linux-gnu-g++` and `qemu-aarch64`
+- Python 3
+- Rust toolchain and Cargo
+
+## Integration Test
+
+```
+./scripts/integration_test.sh
+```
+
+The script builds all components, launches the C++ `data_service`
+under QEMU, and then runs the Python worker and Rust agent on the host.
+Each component's output is checked to ensure the expected messages are
+observed.  Failures will print diagnostics from the failing component.
+
+## Benchmark Harness
+
+```
+python scripts/bench.py
+```
+
+The benchmark iterates over several build profiles (O3, Os, LTO and
+PGO) compiling the `data_service` for each, executing it under QEMU and
+capturing runtime and maximum RSS. Results are written to
+`bench_results.csv` and `bench_results.html` in the repository root.
+
+## Troubleshooting
+
+- Ensure QEMU and the cross compiler are installed and in your `$PATH`.
+- Remove the `bench-build` directory if you need a clean benchmarking
+  run.
+- Use `make clean` to rebuild components from scratch if builds
+  behave unexpectedly.

--- a/scripts/bench.py
+++ b/scripts/bench.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Benchmark harness for cross-compile demo.
+
+Builds the C++ data service with various optimization profiles and
+measures runtime and maximum resident set size using QEMU. Results are
+written to CSV and HTML files.
+"""
+
+from __future__ import annotations
+
+import csv
+import subprocess
+from pathlib import Path
+from dataclasses import dataclass
+
+ROOT = Path(__file__).resolve().parent.parent
+CPP_SRC = ROOT / "cpp-service" / "DataService.cpp"
+BUILD_DIR = ROOT / "bench-build"
+RESULT_CSV = ROOT / "bench_results.csv"
+RESULT_HTML = ROOT / "bench_results.html"
+
+@dataclass
+class Result:
+    profile: str
+    runtime: float
+    rss_kb: int
+
+def run_cmd(cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, check=True, text=True, **kwargs)
+
+def compile_service(flags: list[str], output: Path) -> None:
+    cmd = [
+        "aarch64-linux-gnu-g++",
+        str(CPP_SRC),
+        "-static",
+        "-o",
+        str(output),
+    ] + flags
+    run_cmd(cmd)
+
+def run_service(binary: Path) -> tuple[float, int]:
+    cmd = [
+        "/usr/bin/time",
+        "-f",
+        "%e,%M",
+        "qemu-aarch64",
+        "-L",
+        "/usr/aarch64-linux-gnu",
+        str(binary),
+    ]
+    proc = run_cmd(cmd, capture_output=True)
+    time_str, rss_str = proc.stderr.strip().split(",")
+    return float(time_str), int(rss_str)
+
+def bench_profile(profile: str, flags: list[str]) -> Result:
+    out_dir = BUILD_DIR / profile
+    out_dir.mkdir(parents=True, exist_ok=True)
+    bin_path = out_dir / "data_service"
+
+    if profile == "PGO":
+        # Generate profile data
+        compile_service(flags + ["-fprofile-generate"], bin_path)
+        run_service(bin_path)
+        # Use generated profile
+        compile_service(flags + ["-fprofile-use"], bin_path)
+    else:
+        compile_service(flags, bin_path)
+
+    runtime, rss = run_service(bin_path)
+    return Result(profile, runtime, rss)
+
+def main() -> None:
+    BUILD_DIR.mkdir(exist_ok=True)
+    profiles = {
+        "O3": ["-O3"],
+        "Os": ["-Os"],
+        "LTO": ["-O3", "-flto"],
+        "PGO": ["-O3"],
+    }
+
+    results: list[Result] = []
+    for name, flags in profiles.items():
+        print(f"Building and benchmarking {name} profile...")
+        results.append(bench_profile(name, flags))
+
+    with RESULT_CSV.open("w", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(["profile", "runtime_sec", "rss_kb"])
+        for r in results:
+            writer.writerow([r.profile, f"{r.runtime:.3f}", r.rss_kb])
+
+    with RESULT_HTML.open("w") as f:
+        f.write("<html><body><table border='1'>\n")
+        f.write("<tr><th>Profile</th><th>Runtime (s)</th><th>RSS (KB)</th></tr>\n")
+        for r in results:
+            f.write(
+                f"<tr><td>{r.profile}</td><td>{r.runtime:.3f}</td><td>{r.rss_kb}</td></tr>\n"
+            )
+        f.write("</table></body></html>\n")
+
+    print(f"Results written to {RESULT_CSV} and {RESULT_HTML}")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/integration_test.sh
+++ b/scripts/integration_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Integration test for cross-compile demo
+# Builds all components, runs the aarch64 data service under QEMU,
+# and launches the Python worker and Rust agent on the host.
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"/.. && pwd)"
+cd "$ROOT_DIR"
+
+# Build components
+make build
+
+# Run data service under QEMU
+DATA_LOG=$(mktemp)
+if ! qemu-aarch64 -L /usr/aarch64-linux-gnu cpp-service/data_service >"$DATA_LOG" 2>&1; then
+    echo "data_service failed to start" >&2
+    cat "$DATA_LOG" >&2 || true
+    exit 1
+fi
+if ! grep -q "Data Service running" "$DATA_LOG"; then
+    echo "Unexpected data_service output" >&2
+    cat "$DATA_LOG" >&2
+    exit 1
+fi
+
+echo "data_service output: $(cat "$DATA_LOG")"
+
+# Launch Python worker
+PY_OUT=$(python python-worker/worker.py)
+if ! echo "$PY_OUT" | grep -q "Python worker active"; then
+    echo "Python worker output unexpected" >&2
+    echo "$PY_OUT" >&2
+    exit 1
+fi
+echo "python worker output: $PY_OUT"
+
+# Launch Rust agent
+RS_OUT=$(./rust-agent/target/debug/rust-agent)
+if ! echo "$RS_OUT" | grep -q "Rust agent ready"; then
+    echo "Rust agent output unexpected" >&2
+    echo "$RS_OUT" >&2
+    exit 1
+fi
+echo "rust agent output: $RS_OUT"
+
+echo "Integration test completed successfully" 


### PR DESCRIPTION
## Summary
- Add integration test script that builds components and runs data service under QEMU alongside Python worker and Rust agent
- Provide benchmark harness to evaluate different build profiles and generate CSV/HTML reports
- Document integration and benchmarking steps and troubleshooting tips

## Testing
- `make test`
- `./scripts/integration_test.sh` *(fails: qemu-aarch64: command not found)*
- `python scripts/bench.py` *(fails: No such file or directory: 'aarch64-linux-gnu-g++')*


------
https://chatgpt.com/codex/tasks/task_e_689d62316fc4832ab7407011ae835aa1