### PR TITLE
Add devcontainer for cross compilation environment

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,25 @@
+# syntax=docker/dockerfile:1
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
+
+# Install cross compilers, QEMU, ZeroMQ, SQLite, protoc, Python, Rust, and development tools
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
+    gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
+    qemu-user-static \
+    libzmq3-dev \
+    sqlite3 libsqlite3-dev \
+    protobuf-compiler \
+    python3 python3-pip \
+    pkg-config \
+    git curl wget ccache \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Rust using rustup
+RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable \
+    && /root/.cargo/bin/rustup target add aarch64-unknown-linux-gnu armv7-unknown-linux-gnueabihf
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Default workdir
+WORKDIR /workspace

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+set -e
+
+# Create initial build directories
+mkdir -p build cpp-service/build python-worker/build rust-agent/target
+
+# Generate code from protobuf to prime IntelliSense
+protoc --proto_path=proto --cpp_out=cpp-service --python_out=python-worker proto/data.proto

--- a/devcontainer.json
+++ b/devcontainer.json
@@ -1,0 +1,24 @@
+{
+  "name": "cross-compile-dev",
+  "dockerComposeFile": "docker-compose.yml",
+  "service": "dev",
+  "workspaceFolder": "/workspace",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-vscode.cpptools",
+        "ms-python.python",
+        "rust-lang.rust-analyzer",
+        "ms-azuretools.vscode-docker",
+        "tamasfe.even-better-toml"
+      ]
+    }
+  },
+  "forwardPorts": [5555],
+  "mounts": [
+    "source=build-cache,target=/workspace/build,type=volume",
+    "source=ccache,target=/root/.ccache,type=volume",
+    "source=cargo-target,target=/workspace/rust-agent/target,type=volume"
+  ],
+  "postCreateCommand": "/workspace/.devcontainer/post-create.sh"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  dev:
+    build:
+      context: .
+      dockerfile: .devcontainer/Dockerfile
+    volumes:
+      - .:/workspace:cached
+      - build-cache:/workspace/build
+      - ccache:/root/.ccache
+      - cargo-target:/workspace/rust-agent/target
+    tty: true
+volumes:
+  build-cache:
+  ccache:
+  cargo-target:


### PR DESCRIPTION
## Summary
- add Dockerfile that installs cross-compilers, QEMU, ZeroMQ, SQLite, protoc, Python, and Rust
- configure devcontainer.json with extensions, ports, named volumes, and post-create steps
- provide docker-compose service mounting caches and workspace

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_689d62330294832a9f6f9d5f7c3c841d