### PR TITLE
Implement cross-service structured logging with trace IDs

### DIFF
--- a/cpp-service/DataService.cpp
+++ b/cpp-service/DataService.cpp
@@ -1,6 +1,21 @@
-#include <iostream>
+#include <spdlog/spdlog.h>
+#include <string>
+#include <cstdint>
 
-int main() {
-    std::cout << "Data Service running" << std::endl;
+int main(int argc, char* argv[]) {
+    std::string level = "info";
+    std::uint64_t trace_id = 0;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string arg = argv[i];
+        if (arg == "--log-level" && i + 1 < argc) {
+            level = argv[++i];
+        } else if (arg == "--trace-id" && i + 1 < argc) {
+            trace_id = std::stoull(argv[++i]);
+        }
+    }
+
+    spdlog::set_level(spdlog::level::from_str(level));
+    spdlog::info("[DS1001][trace={}]: Data Service running", trace_id);
     return 0;
 }

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,43 @@
+# Logging Guidelines
+
+This project demonstrates consistent structured logging across the C++ Data Service, Python worker, and Rust agent. Each service accepts an optional `--trace-id` argument used to correlate log messages across languages. Protobuf messages include a `uint64 trace_id` field that should be passed through all services.
+
+## C++ Data Service
+
+```sh
+./data_service --log-level info --trace-id 42
+```
+
+Uses [spdlog](https://github.com/gabime/spdlog) and supports a `--log-level` flag. Message IDs such as `DS1001` are embedded in log lines:
+
+```
+[DS1001][trace=42]: Data Service running
+```
+
+## Python Worker
+
+```sh
+python worker.py --log-level INFO --trace-id 42
+```
+
+Configures the `logging` module with a format that includes message and trace identifiers. Example output:
+
+```
+2024-01-01 00:00:00 INFO [PY1001] [trace=42] Python worker active
+```
+
+## Rust Agent
+
+```sh
+cargo run -- --trace-id 42
+```
+
+Uses the `env_logger` crate with a custom formatter. Example log:
+
+```
+2024-01-01T00:00:00Z INFO [trace=42] [RS1001] Rust agent ready
+```
+
+## Protobuf
+
+`proto/data.proto` defines `trace_id` on all messages. Ensure this value is propagated through every service call.

--- a/proto/data.proto
+++ b/proto/data.proto
@@ -4,9 +4,11 @@ message UpdateUserRequest {
   int32 user_id = 1;
   string field = 2;
   string value = 3;
+  uint64 trace_id = 4;
 }
 
 message UpdateUserResponse {
   bool success = 1;
   string message = 2;
+  uint64 trace_id = 3;
 }

--- a/python-worker/worker.py
+++ b/python-worker/worker.py
@@ -1,7 +1,24 @@
-import sys
+import argparse
+import logging
+
+LOG_FORMAT = "%""%(asctime)s %(levelname)s [%(message_id)s] [trace=%(trace_id)s] %(message)s"""
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(level=level.upper(), format=LOG_FORMAT)
+
 
 def main() -> None:
-    print("Python worker active")
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log-level", default="INFO")
+    parser.add_argument("--trace-id", type=int, default=0)
+    args = parser.parse_args()
+
+    configure_logging(args.log_level)
+    logger = logging.LoggerAdapter(logging.getLogger(__name__), {
+        "trace_id": args.trace_id,
+        "message_id": "PY1001",
+    })
+    logger.info("Python worker active")
 
 if __name__ == "__main__":
     main()

--- a/rust-agent/Cargo.toml
+++ b/rust-agent/Cargo.toml
@@ -4,3 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+log = "0.4"
+env_logger = "0.11"
+chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }

--- a/rust-agent/src/main.rs
+++ b/rust-agent/src/main.rs
@@ -1,5 +1,34 @@
+use chrono::Utc;
+use log::info;
+use std::env;
+
+fn init_logger(trace_id: String) {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info"))
+        .format(move |buf, record| {
+            use std::io::Write;
+            writeln!(
+                buf,
+                "{} {} [{}] [trace={}] {}",
+                Utc::now().to_rfc3339(),
+                record.level(),
+                record.target(),
+                trace_id,
+                record.args()
+            )
+        })
+        .init();
+}
+
 fn main() {
-    println!("Rust agent ready");
+    let args: Vec<String> = env::args().collect();
+    let mut trace_id = String::from("0");
+    for i in 0..args.len() {
+        if args[i] == "--trace-id" && i + 1 < args.len() {
+            trace_id = args[i + 1].clone();
+        }
+    }
+    init_logger(trace_id);
+    info!(target: "RS1001", "Rust agent ready");
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add `trace_id` fields to protobuf messages
- Wire structured logging with trace IDs in C++, Python, and Rust services
- Document logging approach and usage

## Testing
- `make test` *(fails: failed to download crates: [56] Failure when receiving data from the peer (CONNECT tunnel failed, response 403))*
- `g++ -std=c++17 cpp-service/DataService.cpp -o cpp-service/data_service && ./cpp-service/data_service --log-level warn --trace-id 123` *(fails: fatal error: spdlog/spdlog.h: No such file or directory)*
- `python -m py_compile python-worker/worker.py`
- `apt-get update` *(fails: repository 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689d6236fc80832a992d49a25e6170ff