### PR TITLE
Add coverage tooling and traceability matrix

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Set up Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+
+      - name: Install lcov and cargo-tarpaulin
+        run: sudo apt-get update && sudo apt-get install -y lcov && cargo install cargo-tarpaulin
+
+      - name: Build C++ with coverage
+        run: |
+          g++ -std=c++17 --coverage cpp-service/DataService.cpp -o cpp-service/data_service
+          ./cpp-service/data_service
+          lcov --capture --directory cpp-service --output-file cpp-service.info
+          lcov --summary cpp-service.info
+          LINE_COV=$(lcov --summary cpp-service.info 2>&1 | grep lines | awk '{print $2}' | tr -d '%')
+          python - "$LINE_COV" <<'PY'
+import sys
+cov=float(sys.argv[1])
+threshold=80.0
+if cov < threshold:
+    print(f"C++ coverage {cov}% is below threshold {threshold}%")
+    sys.exit(1)
+PY
+
+      - name: Run Python tests with coverage
+        run: |
+          pip install pytest pytest-cov
+          pytest python-worker/tests --cov=python-worker --cov-fail-under=80
+
+      - name: Run Rust tests with coverage
+        working-directory: rust-agent
+        run: |
+          cargo tarpaulin --fail-under 80

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,11 @@
 cpp-service/data_service
 python-worker/__pycache__
 rust-agent/target
+# Coverage artifacts
+**/*.gcda
+**/*.gcno
+coverage.info
+*.lcov
+.coverage
+htmlcov/
+**/__pycache__/

--- a/cpp-service/tests/test_dataservice.sh
+++ b/cpp-service/tests/test_dataservice.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -e
+./cpp-service/data_service | grep "Data Service running"

--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -1,0 +1,9 @@
+# Traceability Matrix
+
+This document maps project features to the tests that validate them.
+
+| Feature | Test Files |
+| --- | --- |
+| Update user data | rust-agent/src/main.rs (tests module `tests::it_runs`) |
+| Start data service | cpp-service/tests/test_dataservice.sh |
+| Activate Python worker | python-worker/tests/test_worker.py |

--- a/python-worker/tests/test_worker.py
+++ b/python-worker/tests/test_worker.py
@@ -1,0 +1,10 @@
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from worker import main
+
+
+def test_main(capsys):
+    main()
+    assert "Python worker active" in capsys.readouterr().out


### PR DESCRIPTION
## Summary
- document feature-to-test mapping
- add C++ and Python smoke tests
- enforce coverage gates for C++, Python, and Rust in CI

## Testing
- `python -m pytest python-worker/tests/test_worker.py -q`
- `g++ -std=c++17 --coverage cpp-service/DataService.cpp -o cpp-service/data_service && ./cpp-service/tests/test_dataservice.sh`
- `cargo test --manifest-path rust-agent/Cargo.toml`
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689d6238513c832aa7c3cc297362b968