### PR TITLE
Add project planning docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ By using modern containerized development practices and proven OSS components, w
 
 Moving forward, this scaffold can be extended with more services or tools as needed (e.g., adding a web UI container, or integrating a simulator for hardware inputs). Its modular nature and adherence to standards mean such additions can be made without restructuring the whole environment. Developers and stakeholders can be confident that this foundation will scale with the project’s needs, all while maintaining the **core principles of real-time, reliable, cross-language communication** that are essential for the product’s success.
 
+## Project Plan
+
+The overall roadmap and milestone breakdown live in [project/plan.md](project/plan.md).
+Current feature status and links to issues or pull requests are tracked in [project/tracking.md](project/tracking.md).
+
 ## Architecture and Technology Stack Overview
 
 To support **embedded cross-platform development** on the NXP i.MX8MP (Cortex-A53) platform, this scaffold follows the proven **Option A architecture** combining **ZeroMQ**, **Protobuf**, **SQLite**, and real-time messaging principles. In this design, a central **Data Service** coordinates state with an in-memory cache and persistent SQLite storage, while multiple microservices (in C++, Python, Rust) communicate via a **ZeroMQ message bus** using **Protocol Buffers** for schema-defined data. This approach provides low-latency IPC (REQ/REP for requests and PUB/SUB for event broadcasting), strongly-typed cross-language messages, and lightweight embeddable persistence. Real-time pub/sub messaging ensures that updates propagate to subscribers immediately, aligning with the platform goal of **real-time data sharing and updates across independent services**. Dynamic service discovery (via **Zyre** library) is included for peer discovery without central brokers, reflecting the requirement for modular extensibility in distributed deployments. Overall, this technology stack is chosen for its **high performance, cross-platform interoperability, and small footprint**, making it ideal for embedded Linux/Android environments.

--- a/project/plan.md
+++ b/project/plan.md
@@ -1,0 +1,27 @@
+# Project Plan
+
+## MVP Goal
+Build a cross-platform development scaffold enabling C++, Python, and Rust services to communicate via ZeroMQ and Protobuf while persisting data with SQLite on the i.MX8MP platform.
+
+## High-Level Architecture
+```
++-------------+     +--------------+     +-----------+
+| Python      | --> | ZeroMQ Bus   | <-- | Rust      |
+| Worker      |     |              |     | Agent     |
++-------------+     +--------------+     +-----------+
+          \            ^
+           \          /
+            v        /
+         +------------------+
+         | C++ Data Service |
+         +------------------+
+               |
+               v
+          SQLite DB
+```
+
+## Milestones
+1. Containerized dev environment and cross-compilation toolchains.
+2. C++ data service with Protobuf schema and SQLite persistence.
+3. Python worker and Rust agent integration over ZeroMQ.
+4. End-to-end tests and CI pipeline.

--- a/project/tracking.md
+++ b/project/tracking.md
@@ -1,0 +1,7 @@
+# Feature Tracking
+
+| Feature | Status | Links |
+| --- | --- | --- |
+| C++ Data Service skeleton | Done | [#1](https://github.com/example/issues/1) |
+| Python worker example | In Progress | [#2](https://github.com/example/issues/2) |
+| Rust agent template | Todo | [#3](https://github.com/example/issues/3) |


### PR DESCRIPTION
## Summary
- add project plan with MVP goal, architecture diagram, and milestones
- create feature tracking table
- reference planning documents from README

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'zmq')*
- `cargo test --manifest-path rust-agent/Cargo.toml` *(fails: failed to download crates index, CONNECT tunnel failed: 403)*

------
https://chatgpt.com/codex/tasks/task_e_689d6b220a7c832a9369327f42ff7c44