### PR TITLE
docs: add contributor guide and references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,23 @@
+# Contributor Guide
+
+## Code Style
+- Rust: run `cargo fmt --all` and `cargo clippy --all-targets --all-features`.
+- Python: format with `black` and lint with `flake8`.
+- C++: format with `clang-format` using the repository configuration.
+
+## Commit Messages
+- Use the conventional commit format: `type: subject` (e.g., `feat: add cache`).
+- Types include: `feat`, `fix`, `docs`, `test`, `chore`, `refactor`, `build`.
+- Keep subjects ≤ 72 characters and in the imperative mood.
+
+## Tests
+- Run `make test` before pushing changes. All tests must pass.
+- Docs-only changes must still run `make test` to confirm nothing breaks.
+
+## Project Documentation
+- Update `plan.md` when the feature roadmap changes or new features are added.
+- Update `tracking.md` as feature work progresses or completes.
+
+## Pull Requests
+- Ensure this guide has been followed before submitting a PR.
+- Each PR requires at least one reviewer approval and a clear description of changes.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 Embedded Cross-Platform Dev Workspace (i.MX8MP Cortex-A53)
 
-## Conclusion 
+## Contributing
+
+Before making changes, please read [AGENTS.md](AGENTS.md) for code style,
+commit message conventions, required tests, and expectations around keeping
+`plan.md` and `tracking.md` up to date.
+
+## Conclusion
 
 This VS Code + DevContainer scaffold is designed to enable a team to quickly start developing cross-platform (C++/Python/Rust) services for the i.MX8MP while ensuring alignment with the **Option A architecture** recommendations (ZeroMQ messaging, Protobuf schemas, SQLite persistence, etc.). It provides a comprehensive environment where everything from writing code, building, running on an emulated target, debugging, benchmarking, and testing is streamlined and reproducible.
 


### PR DESCRIPTION
## Summary
- add root-level AGENTS.md with code style, commit and PR expectations
- note in README to consult AGENTS.md before contributing

## Testing
- `make test` *(fails: Makefile:13: *** missing separator)*
- `cargo test --manifest-path rust-agent/Cargo.toml` *(fails: spurious network error 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'zmq')*

------
https://chatgpt.com/codex/tasks/task_e_689d6b321a60832a901f24fb22031d29