### PR TITLE
feat: store sensor readings and handle control commands

### DIFF
--- a/cpp-service/CMakeLists.txt
+++ b/cpp-service/CMakeLists.txt
@@ -11,8 +11,6 @@ set(CMAKE_SYSTEM_PROCESSOR aarch64)
 set(CMAKE_C_COMPILER aarch64-linux-gnu-gcc)
 set(CMAKE_CXX_COMPILER aarch64-linux-gnu-g++)
 
-add_executable(data_service DataService.cpp)
-
 
 
 find_package(Protobuf REQUIRED)
@@ -20,8 +18,10 @@ include_directories(${Protobuf_INCLUDE_DIRS})
 
 protobuf_generate_cpp(PROTO_SRCS PROTO_HDRS ../proto/data.proto)
 
+add_library(sensor_service SHARED src/service.cpp ${PROTO_SRCS})
+target_include_directories(sensor_service PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
+target_link_libraries(sensor_service PRIVATE protobuf::libprotobuf sqlite3)
+
 add_executable(data_service DataService.cpp Cache.cpp Database.cpp ${PROTO_SRCS})
-
 target_include_directories(data_service PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
-
 target_link_libraries(data_service PRIVATE protobuf::libprotobuf sqlite3 zmq)

--- a/cpp-service/src/service.cpp
+++ b/cpp-service/src/service.cpp
@@ -1,0 +1,78 @@
+#include "data.pb.h"
+#include <mutex>
+#include <sqlite3.h>
+#include <string>
+
+extern "C" {
+
+sqlite3 *service_init(const char *path) {
+  sqlite3 *db = nullptr;
+  if (sqlite3_open(path, &db) != SQLITE_OK) {
+    return nullptr;
+  }
+  const char *sql = "CREATE TABLE IF NOT EXISTS sensor_readings (sensor_id "
+                    "INTEGER, value REAL, timestamp INTEGER);";
+  if (sqlite3_exec(db, sql, nullptr, nullptr, nullptr) != SQLITE_OK) {
+    sqlite3_close(db);
+    return nullptr;
+  }
+  return db;
+}
+
+void service_close(sqlite3 *db) {
+  if (db) {
+    sqlite3_close(db);
+  }
+}
+
+int service_handle_reading(sqlite3 *db, const char *data, int len) {
+  if (!db) {
+    return 0;
+  }
+  SensorReading reading;
+  if (!reading.ParseFromArray(data, len)) {
+    return 0;
+  }
+  const char *sql =
+      "INSERT INTO sensor_readings(sensor_id,value,timestamp) VALUES(?,?,?);";
+  sqlite3_stmt *stmt;
+  if (sqlite3_prepare_v2(db, sql, -1, &stmt, nullptr) != SQLITE_OK) {
+    return 0;
+  }
+  sqlite3_bind_int(stmt, 1, reading.sensor_id());
+  sqlite3_bind_double(stmt, 2, reading.value());
+  sqlite3_bind_int64(stmt, 3, reading.timestamp());
+  bool ok = sqlite3_step(stmt) == SQLITE_DONE;
+  sqlite3_finalize(stmt);
+  return ok ? 1 : 0;
+}
+
+static std::mutex g_mutex;
+static uint64_t g_rate = 0;
+static std::string g_target;
+
+void service_process_command(const char *data, int len) {
+  ControlCommand cmd;
+  if (!cmd.ParseFromArray(data, len)) {
+    return;
+  }
+  std::lock_guard<std::mutex> lock(g_mutex);
+  if (cmd.new_rate() != 0) {
+    g_rate = cmd.new_rate();
+  }
+  if (!cmd.target().empty()) {
+    g_target = cmd.target();
+  }
+}
+
+uint64_t service_get_rate() {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  return g_rate;
+}
+
+const char *service_get_target() {
+  std::lock_guard<std::mutex> lock(g_mutex);
+  return g_target.c_str();
+}
+
+} // extern "C"

--- a/project/plan.md
+++ b/project/plan.md
@@ -25,3 +25,4 @@ Build a cross-platform development scaffold enabling C++, Python, and Rust servi
 2. C++ data service with Protobuf schema and SQLite persistence.
 3. Python worker and Rust agent integration over ZeroMQ.
 4. End-to-end tests and CI pipeline.
+5. Sensor reading ingestion and control command handling.

--- a/project/tracking.md
+++ b/project/tracking.md
@@ -5,3 +5,4 @@
 | C++ Data Service skeleton | Done | [#1](https://github.com/example/issues/1) |
 | Python worker example | In Progress | [#2](https://github.com/example/issues/2) |
 | Rust agent template | Todo | [#3](https://github.com/example/issues/3) |
+| Sensor reading storage and command handling | Done | [#4](https://github.com/example/issues/4) |

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,0 +1,47 @@
+import ctypes
+import pathlib
+import sqlite3
+import sys
+
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from proto import data_pb2
+
+LIB_PATH = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "build"
+    / "cpp-service"
+    / "libsensor_service.so"
+)
+lib = ctypes.CDLL(str(LIB_PATH))
+
+lib.service_init.argtypes = [ctypes.c_char_p]
+lib.service_init.restype = ctypes.c_void_p
+lib.service_close.argtypes = [ctypes.c_void_p]
+lib.service_handle_reading.argtypes = [ctypes.c_void_p, ctypes.c_char_p, ctypes.c_int]
+lib.service_handle_reading.restype = ctypes.c_int
+lib.service_process_command.argtypes = [ctypes.c_char_p, ctypes.c_int]
+lib.service_get_rate.restype = ctypes.c_ulonglong
+lib.service_get_target.restype = ctypes.c_char_p
+
+
+def test_sensor_reading_written(tmp_path):
+    db_path = tmp_path / "readings.db"
+    db = lib.service_init(str(db_path).encode())
+    reading = data_pb2.SensorReading(sensor_id=2, value=3.14, timestamp=111)
+    payload = reading.SerializeToString()
+    assert lib.service_handle_reading(db, payload, len(payload)) == 1
+    lib.service_close(db)
+    conn = sqlite3.connect(db_path)
+    row = conn.execute(
+        "SELECT sensor_id, value, timestamp FROM sensor_readings"
+    ).fetchone()
+    assert row == (2, 3.14, 111)
+    conn.close()
+
+
+def test_control_command_updates_state():
+    cmd = data_pb2.ControlCommand(new_rate=7, target="pump")
+    payload = cmd.SerializeToString()
+    lib.service_process_command(payload, len(payload))
+    assert lib.service_get_rate() == 7
+    assert lib.service_get_target().decode() == "pump"


### PR DESCRIPTION
## Summary
- handle SensorReading messages and persist them to SQLite
- process ControlCommand messages to update rate and target
- test sensor storage and command handling via shared library

## Testing
- `clang-format -i cpp-service/src/service.cpp`
- `black tests/test_service.py`
- `flake8 tests/test_service.py` *(fails: command not found)*
- `pip install flake8` *(fails: Could not find a version that satisfies the requirement flake8)*
- `make test` *(fails: Makefile:13: *** missing separator.  Stop.)*
- `cmake -S cpp-service -B build/cpp-service` *(fails: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR))*
- `pytest` *(fails: ModuleNotFoundError: No module named 'google')*
- `cargo test --manifest-path rust-agent/Cargo.toml` *(fails: failed to download from `https://index.crates.io/config.json`)*

------
https://chatgpt.com/codex/tasks/task_e_689d6e608454832abd2485672b2aecef