### PR TITLE
build: install Rust and curl in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,9 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y cmake protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip
+          apt-get install -y curl cmake protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip
+          curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+          source $HOME/.cargo/env
           rustup target add aarch64-unknown-linux-gnu
           pip install pytest
       - name: Build


### PR DESCRIPTION
## Summary
- install curl and rustup in CI workflow
- add aarch64 target and retain pytest

## Testing
- `make test` (fails: Makefile:13: *** missing separator.  Stop.)

------
https://chatgpt.com/codex/tasks/task_e_689d7110b398832a9df95eecd6e69bf9