### PR TITLE
docs: add service-specific contributor guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,10 @@ Embedded Cross-Platform Dev Workspace (i.MX8MP Cortex-A53)
 
 Before making changes, please read [AGENTS.md](AGENTS.md) for code style,
 commit message conventions, required tests, and expectations around keeping
-`plan.md` and `tracking.md` up to date.
+`plan.md` and `tracking.md` up to date. Service-specific instructions live in
+[cpp-service/AGENTS.md](cpp-service/AGENTS.md),
+[python-worker/AGENTS.md](python-worker/AGENTS.md), and
+[rust-agent/AGENTS.md](rust-agent/AGENTS.md).
 
 ## Continuous Integration
 

--- a/cpp-service/AGENTS.md
+++ b/cpp-service/AGENTS.md
@@ -1,0 +1,25 @@
+# C++ Service Guide
+
+See [../AGENTS.md](../AGENTS.md) for shared repository guidelines.
+
+## Formatting
+- Format C++ sources with `clang-format` using the repo configuration:
+  
+  ```
+  clang-format -i *.cpp *.h
+  ```
+
+## Build
+- Configure and build with CMake:
+  
+  ```
+  cmake -S . -B build
+  cmake --build build
+  ```
+
+## Tests
+- Run the C++ tests via CTest:
+  
+  ```
+  ctest --test-dir build
+  ```

--- a/python-worker/AGENTS.md
+++ b/python-worker/AGENTS.md
@@ -1,0 +1,29 @@
+# Python Worker Guide
+
+See [../AGENTS.md](../AGENTS.md) for repository-wide rules.
+
+## Formatting
+- Format with `black`:
+  
+  ```
+  black .
+  ```
+- Lint with `flake8`:
+  
+  ```
+  flake8
+  ```
+
+## Build
+- Compile to check for syntax errors:
+  
+  ```
+  python -m py_compile *.py
+  ```
+
+## Tests
+- Run Python tests with `pytest`:
+  
+  ```
+  pytest
+  ```

--- a/rust-agent/AGENTS.md
+++ b/rust-agent/AGENTS.md
@@ -1,0 +1,29 @@
+# Rust Agent Guide
+
+See [../AGENTS.md](../AGENTS.md) for repository-wide rules.
+
+## Formatting
+- Format with Rustfmt:
+  
+  ```
+  cargo fmt --all
+  ```
+- Lint with Clippy:
+  
+  ```
+  cargo clippy --all-targets --all-features
+  ```
+
+## Build
+- Build for the target architecture:
+  
+  ```
+  cargo build --target=aarch64-unknown-linux-gnu
+  ```
+
+## Tests
+- Run tests:
+  
+  ```
+  cargo test --target=aarch64-unknown-linux-gnu
+  ```


### PR DESCRIPTION
## Summary
- add AGENTS instructions for cpp, python, and rust components
- reference new guides from top-level README

## Testing
- `make test` *(fails: missing separator in Makefile)*
- `cmake -S cpp-service -B build/cpp-service` *(fails: Could NOT find Protobuf)*
- `cargo test --manifest-path rust-agent/Cargo.toml` *(fails: download of config.json failed: CONNECT tunnel failed, response 403)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'google')*


------
https://chatgpt.com/codex/tasks/task_e_689d70c28620832a8c460ad999094161