### PR TITLE
build: add pre-commit and CI check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,12 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y cmake protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip
+          apt-get install -y cmake protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format
           rustup target add aarch64-unknown-linux-gnu
-          pip install pytest
+          rustup component add clippy rustfmt
+          pip install pytest pre-commit
+      - name: Pre-commit
+        run: pre-commit run --all-files
       - name: Build
         run: make build
       - name: Test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,26 @@
+repos:
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v17.0.6
+    hooks:
+      - id: clang-format
+        args: [--style=file]
+  - repo: https://github.com/psf/black
+    rev: 23.7.0
+    hooks:
+      - id: black
+  - repo: https://github.com/PyCQA/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+  - repo: local
+    hooks:
+      - id: cargo-fmt
+        name: cargo fmt
+        entry: cargo fmt --all -- --check
+        language: system
+        pass_filenames: false
+      - id: cargo-clippy
+        name: cargo clippy
+        entry: cargo clippy --all-targets --all-features -- -D warnings
+        language: system
+        pass_filenames: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,7 @@
 # Contributor Guide
 
 ## Code Style
+- Run `pre-commit install` to enable automatic formatting checks.
 - Rust: run `cargo fmt --all` and `cargo clippy --all-targets --all-features`.
 - Python: format with `black` and lint with `flake8`.
 - C++: format with `clang-format` using the repository configuration.


### PR DESCRIPTION
## Summary
- configure pre-commit with clang-format, black, flake8, cargo fmt, and cargo clippy
- document running `pre-commit install`
- run `pre-commit run --all-files` in CI

## Testing
- `pre-commit run --all-files` *(fails: command not found)*
- `make test` *(fails: Makefile:13: *** missing separator)*

------
https://chatgpt.com/codex/tasks/task_e_689d70c09e0c832a84a0c94cb60ac375