### PR TITLE
docs: add shared utilities directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ The repository is structured to showcase **modular starter examples** in C++, Py
 └── docs/                 # Additional documentation (including this design report)
 ```
 
+For common utilities and protos, see [shared/](shared/README.md).
+
 ### C++ Data Service (`cpp-service/`)
 
 **Role:** The C++ service acts as the **Data Service** – a central authority for storing and distributing data. It hosts a ZeroMQ **REP** socket to handle incoming requests (e.g. update or query data) and a **PUB** socket to broadcast change notifications. It uses the SQLite C++ API (e.g. `sqlite3_exec`) to persist updates to an on-disk database, while maintaining an in-memory cache (e.g. an `std::unordered_map` or similar) for fast reads.

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,0 +1,9 @@
+# Shared Utilities
+
+This directory houses components used across services and languages.
+
+- Reusable helper functions
+- Shared protobuf definitions
+- Cross-service utilities
+
+Add new shared assets here to avoid duplicating code between implementations.


### PR DESCRIPTION
## Summary
- add `shared` directory for cross-service utilities
- reference shared utilities in the main README

## Testing
- `make test` *(fails: Makefile:13: *** missing separator.  Stop.)*

------
https://chatgpt.com/codex/tasks/task_e_689d70bd3758832a81319a3237c3d482