### PR TITLE
docs: add test report for latest make test run

### DIFF
--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -1,0 +1,8 @@
+# Test Report
+
+This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
+
+## b2458e5
+- **Commit**: [`b2458e5`](../../commit/b2458e5) (PR #25: split build into subtargets for languages)
+- **Date**: 2025-08-14
+- **Result**: `make test` failed – Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)


### PR DESCRIPTION
## Summary
- add `tests/TEST_REPORT.md` to capture results of `make test`
- log failing test run for commit `b2458e5` and link to PR

## Testing
- `make test` *(fails: Could NOT find Protobuf)*
- `pre-commit run --files tests/TEST_REPORT.md` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689d787d7374832a82483017bc46cbec