### PR TITLE
docs: add test plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Moving forward, this scaffold can be extended with more services or tools as nee
 
 The overall roadmap and milestone breakdown live in [project/plan.md](project/plan.md).
 Current feature status and links to issues or pull requests are tracked in [project/tracking.md](project/tracking.md).
+Testing objectives are outlined in [project/test_plan.md](project/test_plan.md).
 
 ## Architecture and Technology Stack Overview
 

--- a/project/test_plan.md
+++ b/project/test_plan.md
@@ -1,0 +1,47 @@
+# Test Plan
+
+This document outlines unit, integration, and system test objectives for each subsystem and identifies scenarios required for MVP 1.
+
+## C++ Data Service
+
+### Unit Tests
+- Verify cache insert and retrieval logic.
+- Ensure SQLite writes and reads persist data correctly.
+
+### Integration Tests
+- Request/response over ZeroMQ with a test client.
+- Published updates reach subscribed components.
+
+### System Tests
+- Run alongside Python and Rust services to confirm end-to-end storage and event propagation.
+
+## Python Worker
+
+### Unit Tests
+- Build and parse sensor messages.
+- Handle retry or backoff behavior.
+
+### Integration Tests
+- Exchange messages with the C++ data service over ZeroMQ.
+
+### System Tests
+- Participate in sensor flow with the data service and Rust agent.
+
+## Rust Agent
+
+### Unit Tests
+- Serialize and deserialize command messages.
+- Validate command handling logic.
+
+### Integration Tests
+- Subscribe to data service events and publish responses.
+
+### System Tests
+- Operate with the full stack to verify command messages flow through the bus.
+
+## MVP 1 Scenarios
+
+The following scenarios must be covered before declaring MVP 1 complete:
+
+- **C++ service storage:** Store a sensor reading in SQLite and retrieve it on request.
+- **Python/Rust message flow:** Python worker publishes a message that the C++ service processes and the Rust agent consumes.


### PR DESCRIPTION
## Summary
- add project-level test plan outlining unit, integration, and system tests
- link test plan from README alongside existing plan and tracking docs

## Testing
- `pre-commit run --files README.md project/test_plan.md` *(fails: command not found)*
- `pip install pre-commit` *(fails: tunnel connection failed: 403 Forbidden)*
- `make test` *(fails: Could NOT find Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_689d790f2220832a8b44ae1b9fe631da