### PR TITLE
docs: add test report and update contributor guide

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,7 @@
 ## Tests
 - Run `make test` before pushing changes. All tests must pass.
 - Docs-only changes must still run `make test` to confirm nothing breaks.
+- Refresh `tests/TEST_REPORT.md` with the latest `make test` output on every merged change.
 
 ## Project Documentation
 - Update `plan.md` when the feature roadmap changes or new features are added.

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -1,0 +1,30 @@
+# Test Report
+
+## Command
+`make test` run on 2025-08-14.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
+  Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)
+Call Stack (most recent call first):
+  /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
+  /usr/share/cmake-3.28/Modules/FindProtobuf.cmake:749 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
+  CMakeLists.txt:16 (find_package)
+
+
+-- Configuring incomplete, errors occurred!
+make: *** [Makefile:15: test] Error 1
+
+```
+
+## Summary
+Tests failed: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR).
+
+## Feature Commits
+- C++ Data Service skeleton - `7f2ac3f` ([commit](https://github.com/example/commit/7f2ac3f))
+- Python worker example - `97dc3be` ([commit](https://github.com/example/commit/97dc3be))
+- Rust agent template - _pending_
+- Sensor reading storage and command handling - `626feab` ([commit](https://github.com/example/commit/626feab))


### PR DESCRIPTION
## Summary
- document latest test run with feature commit references
- require refreshing the test report for each merged change

## Testing
- `make test` *(fails: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR))*
- `pre-commit run --files AGENTS.md tests/TEST_REPORT.md` *(fails: pre-commit not installed, installation attempt blocked)*

------
https://chatgpt.com/codex/tasks/task_e_689d7912cbf4832aaa71d511dc9cd6ca