### PR TITLE
ci: add protobuf packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y curl cmake protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format
+          apt-get install -y curl cmake libprotobuf-dev protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           source $HOME/.cargo/env
           rustup target add aarch64-unknown-linux-gnu

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,6 +2,11 @@
 
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
+## 32b4eff
+- **Commit**: [`32b4eff`](../../commit/32b4eff) (ci: add protobuf packages)
+- **Date**: 2025-08-14
+- **Result**: `make test` failed – Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)
+
 ## b2458e5
 - **Commit**: [`b2458e5`](../../commit/b2458e5) (PR #25: split build into subtargets for languages)
 - **Date**: 2025-08-14


### PR DESCRIPTION
## Summary
- install libprotobuf-dev and protobuf-compiler in CI workflow
- record latest failing `make test` run in `tests/TEST_REPORT.md`

## Testing
- `make test` *(fails: Could NOT find Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_689d7a9d1ea4832ab8af7ec744fa5377