### PR TITLE
build: verify cpp library build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Pre-commit
         run: pre-commit run --all-files
       - name: Build
-        run: make build
+        run: |
+          make build
+          test -f build/cpp-service/libsensor_service.so
       - name: Test
         run: make test

--- a/cpp-service/AGENTS.md
+++ b/cpp-service/AGENTS.md
@@ -11,11 +11,20 @@ See [../AGENTS.md](../AGENTS.md) for shared repository guidelines.
 
 ## Build
 - Configure and build with CMake:
-  
+
   ```
   cmake -S . -B build
   cmake --build build
   ```
+
+- To mirror CI locally and produce the shared library used by tests, run from
+  the repository root:
+
+  ```
+  make build
+  ```
+
+  This generates `build/cpp-service/libsensor_service.so`.
 
 ## Tests
 - Run the C++ tests via CTest:


### PR DESCRIPTION
## Summary
- check for libs before running tests in CI
- document cpp build steps for contributors

## Testing
- `pre-commit run --files .github/workflows/ci.yml cpp-service/AGENTS.md` *(fails: command not found)*
- `make test` *(fails: Could NOT find Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_689d7b424a48832a910d5038599a9529