### PR TITLE
fix: address CI protobuf dependency and document auto-merge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,15 +16,13 @@ jobs:
       - name: Install dependencies
         run: |
           apt-get update
-          apt-get install -y curl cmake protobuf-compiler gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format
+          apt-get install -y curl cmake protobuf-compiler libprotobuf-dev gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
-          source $HOME/.cargo/env
+          echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           rustup target add aarch64-unknown-linux-gnu
           rustup component add clippy rustfmt
           pip install pytest pre-commit
       - name: Pre-commit
         run: pre-commit run --all-files
-      - name: Build
-        run: make build
       - name: Test
         run: make test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,3 +23,6 @@
 ## Pull Requests
 - Ensure this guide has been followed before submitting a PR.
 - Each PR requires at least one reviewer approval and a clear description of changes.
+
+## Auto-merge
+- Apply the `automerge` label to enable GitHub's auto-merge once checks and approvals pass.

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,7 +2,7 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
-`make test` run on 2025-08-14.
+`make test` run on 2025-08-14 at 06:04 UTC.
 
 ## Output
 ```
@@ -32,5 +32,10 @@ Tests failed: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCL
 
 ## b2458e5
 - **Commit**: [`b2458e5`](../../commit/b2458e5) (PR #25: split build into subtargets for languages)
+- **Date**: 2025-08-14
+- **Result**: `make test` failed – Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)
+
+## TBD
+- **Commit**: [`TBD`](../../commit/TBD) (PR #TBD: pending)
 - **Date**: 2025-08-14
 - **Result**: `make test` failed – Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)


### PR DESCRIPTION
## Summary
- install protobuf headers and persist Rust toolchain path in CI
- remove redundant build step
- document `automerge` label for automatic merging

## Testing
- `pre-commit run --files AGENTS.md .github/workflows/ci.yml tests/TEST_REPORT.md` *(fails: command not found)*
- `make test` *(fails: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_689d7bfd8df8832aa8488b2ff7a4885b