### PR TITLE
fix: guard zmq import for worker

### DIFF
--- a/python-worker/worker.py
+++ b/python-worker/worker.py
@@ -2,7 +2,15 @@
 
 from __future__ import annotations
 
-import zmq
+from typing import TYPE_CHECKING
+
+try:  # pragma: no cover - optional dependency for runtime use
+    import zmq
+except ModuleNotFoundError:  # pragma: no cover - allow type checking without pyzmq
+    if TYPE_CHECKING:  # pragma: no cover
+        import zmq  # type: ignore
+    zmq = None  # type: ignore
+
 from proto import data_pb2
 
 SUB_ENDPOINT = "tcp://localhost:5556"


### PR DESCRIPTION
## Summary
- guard `zmq` import in `python-worker` to allow type hints without runtime dependency

## Testing
- `black python-worker/worker.py`
- `flake8 python-worker/worker.py` *(fails: command not found, attempted installation but 403 Forbidden)*
- `python -m py_compile python-worker/*.py`
- `pytest` *(fails: ModuleNotFoundError: No module named 'zmq')*
- `make test` *(fails: Could NOT find Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_689deef8f6a8832ab2c8b0b769944f2f