### PR TITLE
fix: handle multipart frames in worker and tests

### DIFF
--- a/python-worker/worker.py
+++ b/python-worker/worker.py
@@ -35,12 +35,21 @@ def process(poller: zmq.Poller, sub_socket, req_socket):
     """
     events = dict(poller.poll())
     if sub_socket in events:
-        raw = sub_socket.recv()
-        event = data_pb2.UpdateUserEvent()
-        event.ParseFromString(raw)
-        request = data_pb2.GetUserRequest(user_id=event.user_id)
-        req_socket.send(request.SerializeToString())
-        return event
+        try:
+            mtype, raw = sub_socket.recv_multipart()
+        except ValueError:  # pragma: no cover
+            return None
+        if mtype == b"UpdateUserEvent":
+            event = data_pb2.UpdateUserEvent()
+            event.ParseFromString(raw)
+            request = data_pb2.GetUserRequest(user_id=event.user_id)
+            req_socket.send_multipart([b"GetUserRequest", request.SerializeToString()])
+            # Maintain REQ/REP handshake
+            try:  # pragma: no cover - best effort
+                req_socket.recv_multipart()
+            except zmq.ZMQError:
+                pass
+            return event
     return None
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,7 +2,6 @@ import threading
 import time
 import zmq
 
-from google.protobuf.message import DecodeError
 from proto import data_pb2
 from python_worker import worker
 
@@ -30,24 +29,32 @@ class DataServiceStub(threading.Thread):
         while not self._stop.is_set():
             socks = dict(poller.poll(100))
             if self.rep in socks:
-                msg = self.rep.recv()
-                try:
+                mtype, msg = self.rep.recv_multipart()
+                if mtype == b"UpdateUserRequest":
                     update = data_pb2.UpdateUserRequest()
                     update.ParseFromString(msg)
                     resp = data_pb2.UpdateUserResponse(success=True, message="ok")
-                    self.rep.send(resp.SerializeToString())
+                    self.rep.send_multipart(
+                        [b"UpdateUserResponse", resp.SerializeToString()]
+                    )
                     event = data_pb2.UpdateUserEvent(
                         user_id=update.user_id,
                         field=update.field,
                         value=update.value,
                     )
-                    self.pub.send(event.SerializeToString())
-                except DecodeError:
+                    self.pub.send_multipart(
+                        [b"UpdateUserEvent", event.SerializeToString()]
+                    )
+                elif mtype == b"GetUserRequest":
                     get_req = data_pb2.GetUserRequest()
                     get_req.ParseFromString(msg)
                     self.received_get_requests.append(get_req)
                     resp = data_pb2.GetUserResponse(found=True, value="")
-                    self.rep.send(resp.SerializeToString())
+                    self.rep.send_multipart(
+                        [b"GetUserResponse", resp.SerializeToString()]
+                    )
+                else:  # pragma: no cover - unknown message type
+                    pass
 
     def stop(self):
         self._stop.set()
@@ -70,9 +77,15 @@ def test_end_to_end_message_flow():
     client = ctx.socket(zmq.REQ)
     client.connect("tcp://127.0.0.1:5555")
     update = data_pb2.UpdateUserRequest(user_id=1, field="name", value="Alice")
-    client.send(update.SerializeToString())
+    client.send_multipart(
+        [
+            b"UpdateUserRequest",
+            update.SerializeToString(),
+        ]
+    )
+    _, raw = client.recv_multipart()
     resp = data_pb2.UpdateUserResponse()
-    resp.ParseFromString(client.recv())
+    resp.ParseFromString(raw)
     assert resp.success
 
     event = worker.process(poller, sub_socket, req_socket)


### PR DESCRIPTION
## Summary
- adjust DataServiceStub to mirror C++ service by sending type and message frames
- handle multipart events and requests in Python worker
- use multipart frames in integration test

## Testing
- `black tests/test_integration.py python-worker/worker.py`
- `flake8 tests/test_integration.py python-worker/worker.py` *(fails: command not found)*
- `cargo fmt --all` *(no output)*
- `cargo clippy --all-targets --all-features` *(fails: can't find crate for `core`)*
- `make test` *(fails: missing Protobuf libraries)*
- `pytest` *(fails: missing modules zmq and proto)*

------
https://chatgpt.com/codex/tasks/task_e_689def375ed4832a8230700ba5d7a92a