### PR TITLE
build: install protobuf dev packages

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -2,7 +2,8 @@
 FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 # Install cross compilers, QEMU, ZeroMQ, SQLite, protoc, Python, Rust, and development tools
-RUN apt-get update && apt-get install -y \
+RUN dpkg --add-architecture arm64 && dpkg --add-architecture armhf && \
+    apt-get update && apt-get install -y \
     build-essential \
     cmake \
     gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
@@ -10,7 +11,8 @@ RUN apt-get update && apt-get install -y \
     qemu-user-static \
     libzmq3-dev \
     sqlite3 libsqlite3-dev \
-    protobuf-compiler \
+    protobuf-compiler libprotobuf-dev \
+    libprotobuf-dev:arm64 libprotobuf-dev:armhf \
     python3 python3-pip \
     pkg-config \
     git curl wget ccache \

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,7 +2,7 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
-`make test` run on 2025-08-14 at 06:18 UTC.
+`make test` run on 2025-08-14 at 14:20 UTC.
 
 ## Output
 ```
@@ -15,6 +15,6 @@ Call Stack (most recent call first):
   /usr/share/cmake-3.28/Modules/FindProtobuf.cmake:749 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
   CMakeLists.txt:16 (find_package)
 
-
+-- Configuring incomplete, errors occurred!
 make: *** [Makefile:15: test] Error 1
 ```


### PR DESCRIPTION
## Summary
- install `libprotobuf-dev` for host, arm64, and armhf in the dev container
- document latest `make test` run

## Testing
- `pre-commit install` *(fails: command not found)*
- `pip install pre-commit` *(fails: Could not find a version that satisfies the requirement pre-commit)*
- `make test` *(fails: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR))*

------
https://chatgpt.com/codex/tasks/task_e_689defe23c20832a8a61a0ecbda1dc66