### PR TITLE
build: update dependency setup

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -8,4 +8,4 @@ linker = "aarch64-linux-gnu-gcc"
 replace-with = "local-registry"
 
 [source.local-registry]
-local-registry = "/workspace/.cargo/local-registry"
+local-registry = ".cargo/local-registry"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -9,7 +9,7 @@ RUN dpkg --add-architecture arm64 && dpkg --add-architecture armhf && \
     gcc-aarch64-linux-gnu g++-aarch64-linux-gnu \
     gcc-arm-linux-gnueabihf g++-arm-linux-gnueabihf \
     qemu-user-static \
-    libzmq3-dev \
+    zeromq libzmq3-dev \
     sqlite3 libsqlite3-dev \
     protobuf-compiler libprotobuf-dev \
     libprotobuf-dev:arm64 libprotobuf-dev:armhf \
@@ -19,7 +19,7 @@ RUN dpkg --add-architecture arm64 && dpkg --add-architecture armhf && \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Python packages required for workers
-RUN pip3 install --no-cache-dir pyzmq protobuf
+RUN pip3 install --no-cache-dir pyzmq protobuf pytest
 
 # Install Rust using rustup
 RUN curl https://sh.rustup.rs -sSf | sh -s -- -y --default-toolchain stable \

--- a/python-worker/requirements.lock
+++ b/python-worker/requirements.lock
@@ -1,0 +1,4 @@
+# Lock file generated manually due to restricted environment
+pyzmq==25.1.1
+protobuf==5.27.2
+pytest==8.2.1

--- a/python-worker/requirements.txt
+++ b/python-worker/requirements.txt
@@ -1,0 +1,3 @@
+pyzmq
+protobuf
+pytest

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,10 +2,12 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
-`make test` run on 2025-08-14 at 14:57 UTC.
+`make test` run on 2025-08-14 at 15:25 UTC.
 
 ## Output
 ```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
 CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
   Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)
 Call Stack (most recent call first):
@@ -13,5 +15,7 @@ Call Stack (most recent call first):
   /usr/share/cmake-3.28/Modules/FindProtobuf.cmake:749 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
   CMakeLists.txt:16 (find_package)
 
+
+-- Configuring incomplete, errors occurred!
 make: *** [Makefile:15: test] Error 1
 ```


### PR DESCRIPTION
## Summary
- ensure dev container installs zeromq and pytest
- add python worker dependency manifests
- point cargo to local crate mirror for offline builds

## Testing
- `black .` *(passed)*
- `flake8` *(fails: command not found)*
- `python -m py_compile *.py` *(passed)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'zmq')*
- `cargo fmt --all --manifest-path rust-agent/Cargo.toml` *(passed)*
- `cargo clippy --all-targets --all-features --manifest-path rust-agent/Cargo.toml` *(fails: local registry index path is not a directory)*
- `cargo fetch --manifest-path rust-agent/Cargo.toml` *(fails: local registry index path is not a directory)*
- `pre-commit run --files .devcontainer/Dockerfile .cargo/config.toml python-worker/requirements.txt python-worker/requirements.lock proto/generated/data_pb2.py tests/TEST_REPORT.md` *(fails: command not found)*
- `make test` *(fails: Could NOT find Protobuf)*

------
https://chatgpt.com/codex/tasks/task_e_689dfe12fdd8832ab17061a7bc9d015c