### PR TITLE
test: reorder imports in worker tests

### DIFF
--- a/python-worker/tests/test_sensor.py
+++ b/python-worker/tests/test_sensor.py
@@ -1,6 +1,6 @@
-import zmq
 import time
 
+import zmq
 from proto import data_pb2
 from python_worker.worker import (
     recv_sensor_reading,

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -1,7 +1,7 @@
 import sys
+from unittest.mock import MagicMock, patch
 
 from proto import data_pb2
-from unittest.mock import MagicMock, patch
 
 
 def load_worker_with_mocked_zmq():


### PR DESCRIPTION
## Summary
- tidy import ordering for `tests/test_worker.py`
- organize imports for `python-worker/tests/test_sensor.py`

## Testing
- `black tests/test_worker.py python-worker/tests/test_sensor.py`
- `python -m py_compile python-worker/worker.py tests/test_worker.py python-worker/tests/test_sensor.py`
- `PYTHONPATH=$PWD pytest tests/test_worker.py python-worker/tests/test_sensor.py`
- `make test` *(fails: Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR))*
- `flake8 tests/test_worker.py python-worker/tests/test_sensor.py` *(command not found; `pip install flake8` failed with 403 Forbidden)*
- `pre-commit run --files tests/test_worker.py python-worker/tests/test_sensor.py` *(command not found; `pip install pre-commit` failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e1a782868832a8f2217fcacfc5587