### PR TITLE
test: build control command with empty fields

### DIFF
--- a/rust-agent/src/lib.rs
+++ b/rust-agent/src/lib.rs
@@ -103,9 +103,9 @@ mod tests {
         sub_socket.set_subscribe(b"").unwrap();
 
         let cmd = ControlCommand {
-            new_rate: 5,
             target: String::new(),
             command: String::new(),
+            new_rate: 5,
         };
         let mut buf = Vec::new();
         cmd.encode(&mut buf).unwrap();


### PR DESCRIPTION
## Summary
- order ControlCommand test fields for clarity

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features` *(fails: local registry path is not a directory)*
- `cargo build --target=aarch64-unknown-linux-gnu` *(fails: local registry path is not a directory)*
- `cargo test --target=aarch64-unknown-linux-gnu` *(fails: local registry path is not a directory)*
- `make test` *(fails: Could NOT find Protobuf)*
- `pre-commit run --files rust-agent/src/lib.rs` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e1c453d64832a9ceffbcc0867fe29