### PR TITLE
test: annotate ctypes import in service test

### DIFF
--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,17 +2,29 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
-`make test` run on 2025-08-14 at 17:30 UTC.
+`make test` run on 2025-08-14 at 18:14 UTC for commit 32536b0.
 
 ## Output
 ```
-CMake Error at /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:230 (message):
-  Could NOT find Protobuf (missing: Protobuf_LIBRARIES Protobuf_INCLUDE_DIR)
-Call Stack (most recent call first):
-  /usr/share/cmake-3.28/Modules/FindPackageHandleStandardArgs.cmake:600 (_FPHSA_FAILURE_MESSAGE)
-  /usr/share/cmake-3.28/Modules/FindProtobuf.cmake:749 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
-  CMakeLists.txt:16 (find_package)
+No tests were found!!!
+gmake[2]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[1]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+ctest --test-dir build/cpp-service || true
+Internal ctest changing into directory: /workspace/cross-compile/build/cpp-service
+Test project /workspace/cross-compile/build/cpp-service
+PYTHONPATH=.:$PYTHONPATH pytest || [ $? -eq 5 ]
+===================================================== test session starts ======================================================
+platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
+rootdir: /workspace/cross-compile
+configfile: pyproject.toml
+collected 8 items
 
+python-worker/tests/test_sensor.py .                                                                                     [ 12%]
+python_worker/tests/test_sensor.py .                                                                                     [ 25%]
+tests/test_integration.py .                                                                                              [ 37%]
+tests/test_service.py ..                                                                                                 [ 62%]
+tests/test_worker.py ...                                                                                                 [100%]
 
-make: *** [Makefile:15: test] Error 1
+====================================================== 8 passed in 0.80s =======================================================
+python -m py_compile python-worker/worker.py
 ```

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,4 @@
-import ctypes
+import ctypes  # for loading the shared library via ctypes.CDLL
 import pathlib
 import sqlite3
 


### PR DESCRIPTION
## Summary
- annotate ctypes import so service test clearly loads shared library
- record latest `make test` results

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e26492c64832ab60ddb107b324d9c