### PR TITLE
feat: handle control commands and shutdown

### DIFF
--- a/rust-agent/Cargo.toml
+++ b/rust-agent/Cargo.toml
@@ -10,6 +10,7 @@ env_logger = "0.11"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 prost = "0.12"
 zmq = "0.10"
+ctrlc = "3"
 
 [build-dependencies]
 prost-build = "0.12"

--- a/rust-agent/src/main.rs
+++ b/rust-agent/src/main.rs
@@ -1,33 +1,96 @@
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, AtomicU64, Ordering},
+};
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
 use prost::Message;
-use std::time::{SystemTime, UNIX_EPOCH};
 
 mod proto {
     include!(concat!(env!("OUT_DIR"), "/data.rs"));
 }
 
-fn main() {
-    // Set up a ZeroMQ publisher.
+use proto::{ControlCommand, SensorReading};
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    env_logger::init();
+
+    // Set up ZeroMQ publisher and subscriber.
     let ctx = zmq::Context::new();
-    let publisher = ctx.socket(zmq::PUB).expect("create pub socket");
-    publisher.bind("tcp://*:5555").expect("bind pub socket");
+    let publisher = ctx.socket(zmq::PUB)?;
+    publisher.bind("tcp://*:5555")?;
 
-    // Construct a mock sensor reading.
-    let ts = SystemTime::now()
-        .duration_since(UNIX_EPOCH)
-        .expect("time went backwards")
-        .as_secs() as i64;
-    let reading = proto::SensorReading {
-        sensor_id: 1,
-        value: 42.0,
-        timestamp: ts,
-    };
+    let subscriber = ctx.socket(zmq::SUB)?;
+    subscriber.connect("tcp://localhost:5556")?;
+    subscriber.set_subscribe(b"")?;
 
-    // Encode and publish the message.
-    let mut buf = Vec::new();
-    reading.encode(&mut buf).expect("encode message");
-    publisher.send(buf, 0).expect("send message");
+    // Shared state for publish rate and shutdown signal.
+    let rate = Arc::new(AtomicU64::new(1));
+    let running = Arc::new(AtomicBool::new(true));
 
-    println!("Published mock SensorReading");
+    // CTRL-C handler for clean shutdown.
+    {
+        let running = running.clone();
+        ctrlc::set_handler(move || {
+            running.store(false, Ordering::SeqCst);
+        })?;
+    }
+
+    // Thread to receive control commands.
+    {
+        let rate = rate.clone();
+        let running = running.clone();
+        thread::spawn(move || {
+            while running.load(Ordering::SeqCst) {
+                match subscriber.recv_bytes(zmq::DONTWAIT) {
+                    Ok(bytes) => match ControlCommand::decode(&*bytes) {
+                        Ok(cmd) => {
+                            if cmd.new_rate > 0 {
+                                rate.store(cmd.new_rate, Ordering::SeqCst);
+                                log::info!("Updated rate to {}s", cmd.new_rate);
+                            }
+                        }
+                        Err(e) => log::error!("Decode ControlCommand: {e}"),
+                    },
+                    Err(e) => {
+                        if e == zmq::Error::EAGAIN {
+                            thread::sleep(Duration::from_millis(100));
+                        } else {
+                            log::error!("Receive ControlCommand: {e}");
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+    }
+
+    // Publishing loop.
+    while running.load(Ordering::SeqCst) {
+        let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as i64;
+
+        let reading = SensorReading {
+            sensor_id: 1,
+            value: 42.0,
+            timestamp: ts,
+        };
+
+        let mut buf = Vec::new();
+        if let Err(e) = reading.encode(&mut buf) {
+            log::error!("Encode SensorReading: {e}");
+            continue;
+        }
+        if let Err(e) = publisher.send(buf, 0) {
+            log::error!("Publish SensorReading: {e}");
+        }
+
+        let delay = rate.load(Ordering::SeqCst);
+        thread::sleep(Duration::from_secs(delay));
+    }
+
+    log::info!("Shutting down");
+    Ok(())
 }
 
 #[cfg(test)]

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -1,8 +1,9 @@
 # Test Report
-This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
+This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the
+ relevant pull request or commit for traceability.
 
 ## Command
-`make test` run on 2025-08-14 at 18:14 UTC for commit 32536b0.
+`make test` run on 2025-08-14 at 18:36 UTC for commit 9ffd3e7.
 
 ## Output
 ```
@@ -25,5 +26,7 @@ tests/test_integration.py .                                                     
 tests/test_service.py ..                                                                                                 [ 62%]
 tests/test_worker.py ...                                                                                                 [100%]
 
+====================================================== 8 passed in 0.88s =======================================================
 python -m py_compile python-worker/worker.py
 ```
+


### PR DESCRIPTION
## Summary
- publish `SensorReading` in a loop with adjustable rate
- listen for `ControlCommand` messages to update rate
- add graceful shutdown handling and update test report

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features` *(fails: failed to download from https://index.crates.io/config.json; 403)*
- `cargo build --target=aarch64-unknown-linux-gnu` *(fails: failed to download from https://index.crates.io/config.json; 403)*
- `cargo test --target=aarch64-unknown-linux-gnu` *(fails: failed to download from https://index.crates.io/config.json; 403)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e2bf26228832a8c8f1ddcea7e4570