### PR TITLE
feat: add ZeroMQ data service

### DIFF
--- a/cpp-service/CMakeLists.txt
+++ b/cpp-service/CMakeLists.txt
@@ -9,4 +9,6 @@ add_library(sensor_service SHARED src/service.cpp proto.cpp)
 target_include_directories(sensor_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(sensor_service PRIVATE sqlite3)
 
-add_executable(data_service DataService.cpp)
+add_executable(data_service DataService.cpp Cache.cpp Database.cpp)
+target_include_directories(data_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(data_service PRIVATE sqlite3 zmq)

--- a/cpp-service/DataService.cpp
+++ b/cpp-service/DataService.cpp
@@ -1,11 +1,284 @@
-#include <chrono>
+#include "Cache.h"
+#include "Database.h"
+
+#include <atomic>
+#include <csignal>
+#include <cstdint>
 #include <iostream>
-#include <thread>
+#include <string>
+#include <zmq.h>
+
+namespace {
+std::atomic<bool> running{true};
+
+void handle_signal(int) { running = false; }
+
+bool read_varint(const uint8_t *&data, const uint8_t *end, uint64_t &out) {
+  out = 0;
+  int shift = 0;
+  while (data < end && shift < 64) {
+    uint8_t byte = *data++;
+    out |= static_cast<uint64_t>(byte & 0x7F) << shift;
+    if ((byte & 0x80) == 0) {
+      return true;
+    }
+    shift += 7;
+  }
+  return false;
+}
+
+void skip_field(const uint8_t *&data, const uint8_t *end, uint32_t wire) {
+  uint64_t len = 0;
+  switch (wire) {
+  case 0:
+    read_varint(data, end, len);
+    break;
+  case 1:
+    data += 8;
+    break;
+  case 2:
+    if (read_varint(data, end, len)) {
+      data += len;
+    }
+    break;
+  case 5:
+    data += 4;
+    break;
+  default:
+    data = end;
+    break;
+  }
+}
+
+bool parse_string(const uint8_t *&data, const uint8_t *end, std::string &out) {
+  uint64_t len;
+  if (!read_varint(data, end, len) || data + len > end) {
+    return false;
+  }
+  out.assign(reinterpret_cast<const char *>(data), len);
+  data += len;
+  return true;
+}
+
+struct UpdateUserRequest {
+  int user_id = 0;
+  std::string field;
+  std::string value;
+  bool Parse(const void *buf, int size) {
+    const uint8_t *data = static_cast<const uint8_t *>(buf);
+    const uint8_t *end = data + size;
+    while (data < end) {
+      uint64_t key;
+      if (!read_varint(data, end, key)) {
+        return false;
+      }
+      uint32_t fieldNum = key >> 3;
+      uint32_t wire = key & 0x7;
+      switch (fieldNum) {
+      case 1: {
+        uint64_t v;
+        if (!read_varint(data, end, v)) {
+          return false;
+        }
+        user_id = static_cast<int>(v);
+        break;
+      }
+      case 2:
+        if (!parse_string(data, end, field)) {
+          return false;
+        }
+        break;
+      case 3:
+        if (!parse_string(data, end, value)) {
+          return false;
+        }
+        break;
+      default:
+        skip_field(data, end, wire);
+        break;
+      }
+    }
+    return true;
+  }
+};
+
+struct GetUserRequest {
+  int user_id = 0;
+  std::string field;
+  bool Parse(const void *buf, int size) {
+    const uint8_t *data = static_cast<const uint8_t *>(buf);
+    const uint8_t *end = data + size;
+    while (data < end) {
+      uint64_t key;
+      if (!read_varint(data, end, key)) {
+        return false;
+      }
+      uint32_t fieldNum = key >> 3;
+      uint32_t wire = key & 0x7;
+      switch (fieldNum) {
+      case 1: {
+        uint64_t v;
+        if (!read_varint(data, end, v)) {
+          return false;
+        }
+        user_id = static_cast<int>(v);
+        break;
+      }
+      case 2:
+        if (!parse_string(data, end, field)) {
+          return false;
+        }
+        break;
+      default:
+        skip_field(data, end, wire);
+        break;
+      }
+    }
+    return true;
+  }
+};
+
+void write_varint(std::string &out, uint64_t value) {
+  while (value > 0x7F) {
+    out.push_back(static_cast<char>((value & 0x7F) | 0x80));
+    value >>= 7;
+  }
+  out.push_back(static_cast<char>(value & 0x7F));
+}
+
+void write_key(std::string &out, uint32_t field, uint32_t wire) {
+  write_varint(out, (static_cast<uint64_t>(field) << 3) | wire);
+}
+
+void write_int(std::string &out, uint32_t field, uint64_t value) {
+  write_key(out, field, 0);
+  write_varint(out, value);
+}
+
+void write_bool(std::string &out, uint32_t field, bool value) {
+  write_int(out, field, value ? 1 : 0);
+}
+
+void write_string(std::string &out, uint32_t field, const std::string &value) {
+  write_key(out, field, 2);
+  write_varint(out, value.size());
+  out.append(value);
+}
+
+std::string make_update_user_response(bool success,
+                                      const std::string &message) {
+  std::string out;
+  write_bool(out, 1, success);
+  write_string(out, 2, message);
+  return out;
+}
+
+std::string make_get_user_response(bool found, const std::string &value) {
+  std::string out;
+  write_bool(out, 1, found);
+  if (found) {
+    write_string(out, 2, value);
+  }
+  return out;
+}
+
+std::string make_update_user_event(int user_id, const std::string &field,
+                                   const std::string &old_value,
+                                   const std::string &new_value) {
+  std::string out;
+  write_int(out, 1, static_cast<uint64_t>(user_id));
+  write_string(out, 2, field);
+  if (!old_value.empty()) {
+    write_string(out, 3, old_value);
+  }
+  write_string(out, 4, new_value);
+  write_string(out, 5, new_value);
+  return out;
+}
+} // namespace
 
 int main() {
+  std::signal(SIGINT, handle_signal);
+  std::signal(SIGTERM, handle_signal);
+
   std::cout << "Data Service running" << std::endl;
-  while (true) {
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+  Cache cache;
+  Database db("users.db", cache);
+
+  void *ctx = zmq_ctx_new();
+  void *rep = zmq_socket(ctx, ZMQ_REP);
+  zmq_bind(rep, "tcp://127.0.0.1:5555");
+  void *pub = zmq_socket(ctx, ZMQ_PUB);
+  zmq_bind(pub, "tcp://127.0.0.1:5556");
+
+  zmq_pollitem_t items[] = {{rep, 0, ZMQ_POLLIN, 0}};
+  while (running) {
+    zmq_poll(items, 1, 100);
+    if (items[0].revents & ZMQ_POLLIN) {
+      zmq_msg_t type_msg;
+      zmq_msg_t payload_msg;
+      zmq_msg_init(&type_msg);
+      zmq_msg_init(&payload_msg);
+      if (zmq_msg_recv(&type_msg, rep, 0) == -1) {
+        continue;
+      }
+      if (zmq_msg_recv(&payload_msg, rep, 0) == -1) {
+        zmq_msg_close(&type_msg);
+        continue;
+      }
+      std::string mtype(static_cast<char *>(zmq_msg_data(&type_msg)),
+                        zmq_msg_size(&type_msg));
+      std::string payload(static_cast<char *>(zmq_msg_data(&payload_msg)),
+                          zmq_msg_size(&payload_msg));
+      zmq_msg_close(&type_msg);
+      zmq_msg_close(&payload_msg);
+
+      if (mtype == "UpdateUserRequest") {
+        UpdateUserRequest req;
+        if (req.Parse(payload.data(), static_cast<int>(payload.size()))) {
+          std::string old_value = db.GetUser(req.user_id, req.field);
+          bool ok = db.UpdateUser(req.user_id, req.field, req.value);
+          auto resp = make_update_user_response(ok, ok ? "ok" : "error");
+          zmq_send(rep, "UpdateUserResponse", 17, ZMQ_SNDMORE);
+          zmq_send(rep, resp.data(), resp.size(), 0);
+          if (ok) {
+            auto event = make_update_user_event(req.user_id, req.field,
+                                                old_value, req.value);
+            zmq_send(pub, "UpdateUserEvent", 15, ZMQ_SNDMORE);
+            zmq_send(pub, event.data(), event.size(), 0);
+            std::cout << "Updated user " << req.user_id << " field "
+                      << req.field << std::endl;
+          }
+        } else {
+          auto resp = make_update_user_response(false, "invalid");
+          zmq_send(rep, "UpdateUserResponse", 17, ZMQ_SNDMORE);
+          zmq_send(rep, resp.data(), resp.size(), 0);
+        }
+      } else if (mtype == "GetUserRequest") {
+        GetUserRequest req;
+        if (req.Parse(payload.data(), static_cast<int>(payload.size()))) {
+          std::string value = db.GetUser(req.user_id, req.field);
+          bool found = !value.empty();
+          auto resp = make_get_user_response(found, value);
+          zmq_send(rep, "GetUserResponse", 15, ZMQ_SNDMORE);
+          zmq_send(rep, resp.data(), resp.size(), 0);
+          std::cout << "Get user " << req.user_id << " field " << req.field
+                    << std::endl;
+        } else {
+          auto resp = make_get_user_response(false, "");
+          zmq_send(rep, "GetUserResponse", 15, ZMQ_SNDMORE);
+          zmq_send(rep, resp.data(), resp.size(), 0);
+        }
+      } else {
+        zmq_send(rep, "", 0, 0);
+      }
+    }
   }
+
+  zmq_close(rep);
+  zmq_close(pub);
+  zmq_ctx_term(ctx);
+  std::cout << "Data Service shutting down" << std::endl;
   return 0;
 }

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,28 +2,16 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
-`make test` run on 2025-08-14 at 18:14 UTC for commit 32536b0.
+`make test` run on 2025-08-14 at 18:40 UTC for commit 9bff27a.
 
 ## Output
 ```
-No tests were found!!!
-gmake[2]: Leaving directory '/workspace/cross-compile/build/cpp-service'
-gmake[1]: Leaving directory '/workspace/cross-compile/build/cpp-service'
-ctest --test-dir build/cpp-service || true
-Internal ctest changing into directory: /workspace/cross-compile/build/cpp-service
-Test project /workspace/cross-compile/build/cpp-service
-PYTHONPATH=.:$PYTHONPATH pytest || [ $? -eq 5 ]
-===================================================== test session starts ======================================================
-platform linux -- Python 3.12.10, pytest-8.4.1, pluggy-1.6.0
-rootdir: /workspace/cross-compile
-configfile: pyproject.toml
-collected 8 items
-
-python-worker/tests/test_sensor.py .                                                                                     [ 12%]
-python_worker/tests/test_sensor.py .                                                                                     [ 25%]
-tests/test_integration.py .                                                                                              [ 37%]
-tests/test_service.py ..                                                                                                 [ 62%]
-tests/test_worker.py ...                                                                                                 [100%]
-
-python -m py_compile python-worker/worker.py
+/workspace/cross-compile/cpp-service/DataService.cpp:9:10: fatal error: zmq.h: No such file or directory
+    9 | #include <zmq.h>
+      |          ^~~~~~~
+compilation terminated.
+gmake[3]: *** [CMakeFiles/data_service.dir/build.make:76: CMakeFiles/data_service.dir/DataService.cpp.o] Error 1
+gmake[2]: *** [CMakeFiles/Makefile2:111: CMakeFiles/data_service.dir/all] Error 2
+gmake[1]: *** [Makefile:91: all] Error 2
+make: *** [Makefile:14: test] Error 2
 ```


### PR DESCRIPTION
## Summary
- replace placeholder loop with ZeroMQ REP/PUB handling
- parse user requests and publish update events
- wire up build for data service

## Testing
- `make test` *(fails: fatal error: zmq.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e2bec71a0832a97c8fdedd1c7caf9