### PR TITLE
test: exercise real service in integration test

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import pathlib
 import subprocess
 import threading
@@ -13,6 +14,7 @@ from proto import data_pb2
 from python_worker import worker
 
 
+@contextlib.contextmanager
 def _launch_service() -> subprocess.Popen[bytes]:
     """Build and launch the ARM data service under QEMU."""
 
@@ -26,14 +28,20 @@ def _launch_service() -> subprocess.Popen[bytes]:
     )
     # Give the service time to bind to its sockets
     time.sleep(0.5)
-    return proc
+    try:
+        yield proc
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:  # pragma: no cover - best effort
+            proc.kill()
 
 
 def test_end_to_end_message_flow() -> None:
     """Ensure that an update flows through the service and worker."""
 
-    proc = _launch_service()
-    try:
+    with _launch_service():
         poller, sub_socket, req_socket = worker.setup()
         time.sleep(0.2)
 
@@ -65,9 +73,3 @@ def test_end_to_end_message_flow() -> None:
         ctx.term()
         sub_socket.close(0)
         req_socket.close(0)
-    finally:
-        proc.terminate()
-        try:
-            proc.wait(timeout=5)
-        except subprocess.TimeoutExpired:  # pragma: no cover - best effort
-            proc.kill()


### PR DESCRIPTION
## Summary
- build and run the C++ data service in integration tests
- ensure service is terminated cleanly

## Testing
- `pre-commit run --files tests/test_integration.py` *(fails: command not found)*
- `make test` *(fails: zmq.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e304aaed8832ab70104089233c72f