### PR TITLE
test: add threading and time imports

### DIFF
--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,10 +2,10 @@
 
 from __future__ import annotations
 
-import pathlib
-import subprocess
 import threading
 import time
+import pathlib
+import subprocess
 
 import zmq
 


### PR DESCRIPTION
## Summary
- Place threading and time imports at the top of the integration test

## Testing
- `python -m black tests/test_integration.py`
- `python -m flake8 tests/test_integration.py` *(fails: No module named flake8)*
- `pre-commit run --files tests/test_integration.py` *(fails: command not found)*
- `make test` *(fails: zmq.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e304ed14c832a8e8821f71619977d