### PR TITLE
test: import ctypes in service test

### DIFF
--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -3,6 +3,39 @@ This document summarizes the latest `make test` run for each merged feature. Inc
  relevant pull request or commit for traceability.
 
 ## Command
+`make test` run on 2025-08-14 at 18:55 UTC for commit 88c582d.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Configuring done (0.0s)
+-- Generating done (0.0s)
+-- Build files have been written to: /workspace/cross-compile/build/cpp-service
+cmake --build build/cpp-service
+gmake[1]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+[ 42%] Built target sensor_service
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+[ 57%] Building CXX object CMakeFiles/data_service.dir/DataService.cpp.o
+/workspace/cross-compile/cpp-service/DataService.cpp:9:10: fatal error: zmq.h: No such file or directory
+    9 | #include <zmq.h>
+      |          ^~~~~~~
+compilation terminated.
+gmake[3]: *** [CMakeFiles/data_service.dir/build.make:76: CMakeFiles/data_service.dir/DataService.cpp.o] Error 1
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: *** [CMakeFiles/Makefile2:111: CMakeFiles/data_service.dir/all] Error 2
+gmake[2]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[1]: *** [Makefile:91: all] Error 2
+gmake[1]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+make: *** [Makefile:14: test] Error 2
+```
+=======
+## Command
 `make test` run on 2025-08-14 at 18:40 UTC for commit 9bff27a.
 
 ## Output

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,4 +1,4 @@
-import ctypes  # for loading the shared library via ctypes.CDLL
+import ctypes
 import pathlib
 import sqlite3
 


### PR DESCRIPTION
## Summary
- import ctypes in tests/test_service.py
- record latest failing `make test` output

## Testing
- `black tests/test_service.py`
- `flake8 tests/test_service.py` *(fails: command not found)*
- `pre-commit run --files tests/test_service.py` *(fails: command not found)*
- `make test` *(fails: fatal error: zmq.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e304c9184832ab8f3c89dc4d6b217