### PR TITLE
feat: handle control commands in rust agent

### DIFF
--- a/rust-agent/src/main.rs
+++ b/rust-agent/src/main.rs
@@ -38,7 +38,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     // Thread to receive control commands.
-    {
+    let sub_handle = {
         let rate = rate.clone();
         let running = running.clone();
         thread::spawn(move || {
@@ -63,8 +63,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                     }
                 }
             }
-        });
-    }
+            if let Err(e) = subscriber.close() {
+                log::error!("Close subscriber: {e}");
+            }
+        })
+    };
 
     // Publishing loop.
     while running.load(Ordering::SeqCst) {
@@ -90,6 +93,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     }
 
     log::info!("Shutting down");
+    if let Err(e) = publisher.close() {
+        log::error!("Close publisher: {e}");
+    }
+    if let Err(e) = sub_handle.join() {
+        log::error!("Join control thread: {e:?}");
+    }
     Ok(())
 }
 

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -1,7 +1,39 @@
 # Test Report
-This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the
- relevant pull request or commit for traceability.
+This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
+## Command
+`make test` run on 2025-08-14 at 18:57 UTC for commit cfdef31.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Configuring done (0.0s)
+-- Generating done (0.0s)
+-- Build files have been written to: /workspace/cross-compile/build/cpp-service
+cmake --build build/cpp-service
+gmake[1]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+[ 42%] Built target sensor_service
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+[ 57%] Building CXX object CMakeFiles/data_service.dir/DataService.cpp.o
+/workspace/cross-compile/cpp-service/DataService.cpp:9:10: fatal error: zmq.h: No such file or directory
+    9 | #include <zmq.h>
+      |          ^~~~~~~
+compilation terminated.
+gmake[3]: *** [CMakeFiles/data_service.dir/build.make:76: CMakeFiles/data_service.dir/DataService.cpp.o] Error 1
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: *** [CMakeFiles/Makefile2:111: CMakeFiles/data_service.dir/all] Error 2
+gmake[2]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[1]: *** [Makefile:91: all] Error 2
+gmake[1]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+make: *** [Makefile:14: test] Error 2
+```
+=======
 ## Command
 `make test` run on 2025-08-14 at 18:40 UTC for commit 9bff27a.
 


### PR DESCRIPTION
## Summary
- receive `ControlCommand` messages to adjust publish rate
- close sockets and join control thread for graceful shutdown
- record latest `make test` run

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features --offline` *(fails: couldn't read out/data.rs)*
- `cargo build --offline` *(fails: couldn't read out/data.rs)*
- `cargo build --target=aarch64-unknown-linux-gnu --offline` *(fails: can't find crate for `core`)*
- `cargo test --target=aarch64-unknown-linux-gnu --offline` *(fails: can't find crate for `core`)*
- `rustup target add aarch64-unknown-linux-gnu` *(fails: unsuccessful tunnel)*
- `make test` *(fails: fatal error: zmq.h: No such file or directory)*
- `apt-get update && apt-get install -y libzmq3-dev` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689e304bbed4832a91c2d2ce988ceb6b