### PR TITLE
feat: integrate zeromq service with tests

### DIFF
--- a/cpp-service/DataService.cpp
+++ b/cpp-service/DataService.cpp
@@ -12,7 +12,11 @@
 namespace {
 std::atomic<bool> running{true};
 
-void handle_signal(int) { running = false; }
+void handle_signal(int signum) {
+  std::cout << "Signal " << signum << " received, initiating shutdown"
+            << std::endl;
+  running = false;
+}
 
 bool read_varint(const uint8_t *&data, const uint8_t *end, uint64_t &out) {
   out = 0;

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,6 +2,41 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
+`make test` run on 2025-08-14 at 19:12 UTC for commit 48e1324.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Configuring done (0.0s)
+-- Generating done (0.0s)
+-- Build files have been written to: /workspace/cross-compile/build/cpp-service
+cmake --build build/cpp-service
+gmake[1]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+[ 42%] Built target sensor_service
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+[ 57%] Building CXX object CMakeFiles/data_service.dir/DataService.cpp.o
+/workspace/cross-compile/cpp-service/DataService.cpp:10:10: fatal error: zmq.h: No such file or directory
+   10 | #include <zmq.h>
+      |          ^~~~~~~
+compilation terminated.
+gmake[3]: *** [CMakeFiles/data_service.dir/build.make:76: CMakeFiles/data_service.dir/DataService.cpp.o] Error 1
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: *** [CMakeFiles/Makefile2:111: CMakeFiles/data_service.dir/all] Error 2
+gmake[2]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[1]: *** [Makefile:91: all] Error 2
+gmake[1]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+make: *** [Makefile:14: test] Error 2
+```
+
+=======
+
+## Command
 `make test` run on 2025-08-14 at 18:57 UTC for commit cfdef31.
 
 ## Output

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -3,11 +3,10 @@
 from __future__ import annotations
 
 import contextlib
+import pathlib
 import subprocess
 import threading
 import time
-import pathlib
-import subprocess
 
 import zmq
 


### PR DESCRIPTION
## Summary
- log received signals in the data service for graceful shutdown
- tidy integration test imports and launch the built service under QEMU
- record latest `make test` output

## Testing
- `black tests/test_integration.py tests/test_service.py tests/test_worker.py`
- `flake8 tests/test_integration.py tests/test_service.py tests/test_worker.py` *(fails: command not found)*
- `pre-commit run --files cpp-service/DataService.cpp tests/test_integration.py tests/test_service.py tests/test_worker.py` *(fails: command not found)*
- `make test` *(fails: missing zmq.h)*

------
https://chatgpt.com/codex/tasks/task_e_689e33ffae68832a8d0a41708fb012d2