### PR TITLE
feat: handle control command for sensor

### DIFF
--- a/rust-agent/src/main.rs
+++ b/rust-agent/src/main.rs
@@ -1,6 +1,6 @@
 use std::sync::{
     Arc,
-    atomic::{AtomicBool, AtomicU64, Ordering},
+    atomic::{AtomicBool, AtomicI32, AtomicU64, Ordering},
 };
 use std::thread;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -25,8 +25,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     subscriber.connect("tcp://localhost:5556")?;
     subscriber.set_subscribe(b"")?;
 
-    // Shared state for publish rate and shutdown signal.
+    // Shared state for publish rate, target sensor, and shutdown signal.
     let rate = Arc::new(AtomicU64::new(1));
+    let sensor_id = Arc::new(AtomicI32::new(1));
     let running = Arc::new(AtomicBool::new(true));
 
     // CTRL-C handler for clean shutdown.
@@ -40,6 +41,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Thread to receive control commands.
     let sub_handle = {
         let rate = rate.clone();
+        let sensor_id = sensor_id.clone();
         let running = running.clone();
         thread::spawn(move || {
             while running.load(Ordering::SeqCst) {
@@ -49,6 +51,15 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                             if cmd.new_rate > 0 {
                                 rate.store(cmd.new_rate, Ordering::SeqCst);
                                 log::info!("Updated rate to {}s", cmd.new_rate);
+                            }
+                            if !cmd.target.is_empty() {
+                                if let Ok(id) = cmd.target.parse() {
+                                    sensor_id.store(id, Ordering::SeqCst);
+                                    log::info!("Updated sensor id to {}", id);
+                                }
+                            }
+                            if cmd.command == "shutdown" {
+                                running.store(false, Ordering::SeqCst);
                             }
                         }
                         Err(e) => log::error!("Decode ControlCommand: {e}"),
@@ -74,7 +85,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         let ts = SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() as i64;
 
         let reading = SensorReading {
-            sensor_id: 1,
+            sensor_id: sensor_id.load(Ordering::SeqCst),
             value: 42.0,
             timestamp: ts,
         };

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,6 +2,39 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
+`make test` run on 2025-08-14 at 19:18 UTC for commit 68d454f.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Configuring done (0.0s)
+-- Generating done (0.0s)
+-- Build files have been written to: /workspace/cross-compile/build/cpp-service
+cmake --build build/cpp-service
+gmake[1]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+[ 42%] Built target sensor_service
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+[ 57%] Building CXX object CMakeFiles/data_service.dir/DataService.cpp.o
+/workspace/cross-compile/cpp-service/DataService.cpp:10:10: fatal error: zmq.h: No such file or directory
+   10 | #include <zmq.h>
+      |          ^~~~~~~
+compilation terminated.
+gmake[3]: *** [CMakeFiles/data_service.dir/build.make:76: CMakeFiles/data_service.dir/DataService.cpp.o] Error 1
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: *** [CMakeFiles/Makefile2:111: CMakeFiles/data_service.dir/all] Error 2
+gmake[2]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[1]: *** [Makefile:91: all] Error 2
+gmake[1]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+make: *** [Makefile:14: test] Error 2
+```
+
+## Command
 `make test` run on 2025-08-14 at 18:57 UTC for commit cfdef31.
 
 ## Output


### PR DESCRIPTION
## Summary
- allow updating sensor id and rate via ControlCommand
- support shutdown control message for graceful exit

## Testing
- `cargo fmt --all --manifest-path rust-agent/Cargo.toml`
- `cargo clippy --all-targets --all-features --manifest-path rust-agent/Cargo.toml` *(fails: failed to get `chrono` as a dependency)*
- `cargo build --target=aarch64-unknown-linux-gnu --manifest-path rust-agent/Cargo.toml` *(fails: failed to get `chrono` as a dependency)*
- `cargo test --target=aarch64-unknown-linux-gnu --manifest-path rust-agent/Cargo.toml` *(fails: failed to get `chrono` as a dependency)*
- `make test` *(fails: zmq.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e358480e8832a891791f1c9b78c17