### PR TITLE
fix: align Test step in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,5 +28,5 @@ jobs:
         run: |
           make build
           test -f build/cpp-service/libsensor_service.so
-     - name: Test
+      - name: Test
         run: make test

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,6 +2,39 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
+`make test` run on 2025-08-14 at 20:21 UTC for commit d81afb1.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Configuring done (0.0s)
+-- Generating done (0.0s)
+-- Build files have been written to: /workspace/cross-compile/build/cpp-service
+cmake --build build/cpp-service
+gmake[1]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+[ 42%] Built target sensor_service
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[3]: Entering directory '/workspace/cross-compile/build/cpp-service'
+[ 57%] Building CXX object CMakeFiles/data_service.dir/DataService.cpp.o
+/workspace/cross-compile/cpp-service/DataService.cpp:10:10: fatal error: zmq.h: No such file or directory
+   10 | #include <zmq.h>
+      |          ^~~~~~~
+compilation terminated.
+gmake[3]: *** [CMakeFiles/data_service.dir/build.make:76: CMakeFiles/data_service.dir/DataService.cpp.o] Error 1
+gmake[3]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[2]: *** [CMakeFiles/Makefile2:111: CMakeFiles/data_service.dir/all] Error 2
+gmake[2]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+gmake[1]: *** [Makefile:91: all] Error 2
+gmake[1]: Leaving directory '/workspace/cross-compile/build/cpp-service'
+make: *** [Makefile:14: test] Error 2
+```
+
+## Command
 `make test` run on 2025-08-14 at 19:18 UTC for commit 68d454f.
 
 ## Output


### PR DESCRIPTION
## Summary
- align the `Test` step indentation in CI workflow
- record latest `make test` output

## Testing
- `pre-commit run --files .github/workflows/ci.yml` *(fails: command not found)*
- `make test` *(fails: DataService.cpp:10:10: fatal error: zmq.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_689e445c3684832a9fb73b8e4b3fd5a5