### PR TITLE
build: use pkg-config for ZeroMQ

### DIFF
--- a/cpp-service/CMakeLists.txt
+++ b/cpp-service/CMakeLists.txt
@@ -5,10 +5,14 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(ZMQ REQUIRED libzmq)
+
 add_library(sensor_service SHARED src/service.cpp proto.cpp)
 target_include_directories(sensor_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_link_libraries(sensor_service PRIVATE sqlite3)
 
 add_executable(data_service DataService.cpp Cache.cpp Database.cpp)
 target_include_directories(data_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(data_service PRIVATE sqlite3 zmq)
+target_include_directories(data_service PRIVATE ${ZMQ_INCLUDE_DIRS})
+target_link_libraries(data_service PRIVATE sqlite3 ${ZMQ_LIBRARIES})

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,6 +2,29 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
+`make test` run on 2025-08-14 at 20:20 UTC for commit 6c1a6b0.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Checking for module 'libzmq'
+--   Package 'libzmq', required by 'virtual:world', not found
+CMake Error at /usr/share/cmake-3.28/Modules/FindPkgConfig.cmake:619 (message):
+  The following required packages were not found:
+
+   - libzmq
+
+Call Stack (most recent call first):
+  /usr/share/cmake-3.28/Modules/FindPkgConfig.cmake:841 (_pkg_check_modules_internal)
+  CMakeLists.txt:9 (pkg_check_modules)
+
+
+-- Configuring incomplete, errors occurred!
+make: *** [Makefile:13: test] Error 1
+```
+
+## Command
 `make test` run on 2025-08-14 at 19:18 UTC for commit 68d454f.
 
 ## Output


### PR DESCRIPTION
## Summary
- configure C++ data_service to locate ZeroMQ via pkg-config
- log latest `make test` output

## Testing
- `pre-commit run --files cpp-service/CMakeLists.txt tests/TEST_REPORT.md` *(fails: command not found)*
- `make test` *(fails: libzmq not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e4465347c832a862b932e8303b2da