### PR TITLE
build: add pyzmq and protobuf dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "cross-compile"
 version = "0.1.0"
 requires-python = ">=3.10"
-dependencies = []
+dependencies = ["pyzmq", "protobuf"]
 
 [build-system]
 requires = ["setuptools"]


### PR DESCRIPTION
## Summary
- add pyzmq and protobuf to project dependencies

## Testing
- `pre-commit run --files pyproject.toml` *(fails: command not found)*
- `make test` *(fails: libzmq missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e48ab4924832a9e7cb1ee0916f738