### PR TITLE
build: install test tooling dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           rustup target add aarch64-unknown-linux-gnu
           rustup component add clippy rustfmt
-          pip install pytest pre-commit
+          pip install pytest pre-commit pyzmq protobuf
       - name: Pre-commit
         run: pre-commit run --all-files
       - name: Build

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,6 +2,29 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
+`make test` run on 2025-08-14 at 20:39 UTC for commit 03f66d5.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Checking for module 'libzmq'
+--   Package 'libzmq', required by 'virtual:world', not found
+CMake Error at /usr/share/cmake-3.28/Modules/FindPkgConfig.cmake:619 (message):
+  The following required packages were not found:
+
+   - libzmq
+
+Call Stack (most recent call first):
+  /usr/share/cmake-3.28/Modules/FindPkgConfig.cmake:841 (_pkg_check_modules_internal)
+  CMakeLists.txt:9 (pkg_check_modules)
+
+
+-- Configuring incomplete, errors occurred!
+make: *** [Makefile:13: test] Error 1
+```
+
+## Command
 `make test` run on 2025-08-14 at 20:20 UTC for commit 6c1a6b0.
 
 ## Output


### PR DESCRIPTION
## Summary
- install pytest, pre-commit, pyzmq, protobuf for CI tests
- refresh test report with latest failing run

## Testing
- `pre-commit install` *(fails: command not found)*
- `pre-commit run --files .github/workflows/ci.yml tests/TEST_REPORT.md` *(fails: command not found)*
- `make test` *(fails: libzmq missing)*

------
https://chatgpt.com/codex/tasks/task_e_689e48baa530832a9fb46edaf5ab3d92