### PR TITLE
build: set Rust edition to 2021

### DIFF
--- a/rust-agent/Cargo.toml
+++ b/rust-agent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-agent"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 build = "build.rs"
 
 [dependencies]


### PR DESCRIPTION
## Summary
- use Rust 2021 edition for rust-agent crate

## Testing
- `cargo fmt --all`
- `cargo clippy --all-targets --all-features` *(fails: failed to get `chrono` due to 403 from crates.io)*
- `cargo build --target=aarch64-unknown-linux-gnu` *(fails: failed to get `chrono` due to 403 from crates.io)*
- `cargo test --target=aarch64-unknown-linux-gnu` *(fails: failed to get `chrono` due to 403 from crates.io)*
- `make test` *(fails: missing libzmq; package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e48d8ae0c832a82fef8d447e79366