### PR TITLE
build: enable arm64 packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,13 +13,22 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+      - name: Enable arm64 packages
+        run: |
+          sudo dpkg --add-architecture arm64
+          sudo tee /etc/apt/sources.list.d/arm64.list >/dev/null <<'EOF'
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main universe multiverse restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main universe multiverse restricted
+          deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main universe multiverse restricted
+          EOF
+          sudo apt-get update
       - name: Install dependencies
         run: |
-          apt-get update
-          apt-get install -y \
+          sudo apt-get install -y \
             curl cmake libprotobuf-dev protobuf-compiler \
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format \
-            libzmq3-dev libzmq3-dev:arm64 libsqlite3-dev libsqlite3-dev:arm64 pkg-config \
+            libzmq3-dev libsqlite3-dev pkg-config \
+            libzmq3-dev:arm64 libsqlite3-dev:arm64 \
             qemu-user qemu-user-static qemu-system-aarch64
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH

--- a/tests/TEST_REPORT.md
+++ b/tests/TEST_REPORT.md
@@ -2,6 +2,28 @@
 This document summarizes the latest `make test` run for each merged feature. Include the abbreviated commit ID and a link to the relevant pull request or commit for traceability.
 
 ## Command
+`make test` run on 2025-08-14 at 20:52 UTC for commit 4bf9863.
+
+## Output
+```
+./scripts/gen-protos.sh
+cmake -S cpp-service -B build/cpp-service
+-- Checking for module 'libzmq'
+--   Package 'libzmq', required by 'virtual:world', not found
+CMake Error at /usr/share/cmake-3.28/Modules/FindPkgConfig.cmake:619 (message):
+  The following required packages were not found:
+
+   - libzmq
+
+Call Stack (most recent call first):
+  /usr/share/cmake-3.28/Modules/FindPkgConfig.cmake:841 (_pkg_check_modules_internal)
+  CMakeLists.txt:9 (pkg_check_modules)
+
+
+-- Configuring incomplete, errors occurred!
+make: *** [Makefile:13: test] Error 1
+```
+
 `make test` run on 2025-08-14 at 20:22 UTC for commit d81afb1.
 
 ## Output


### PR DESCRIPTION
## Summary
- add arm64 package sources in CI workflow
- install cross-arch libs and qemu tools
- record latest `make test` output

## Testing
- `pre-commit install` *(fails: command not found)*
- `make test` *(fails: Package 'libzmq' not found)*

------
https://chatgpt.com/codex/tasks/task_e_689e4b9f0d58832ab2a435bc58327b07