### PR TITLE
test: poll for worker message arrival

### DIFF
--- a/docs/traceability.md
+++ b/docs/traceability.md
@@ -2,8 +2,12 @@
 
 This document maps project features to the tests that validate them.
 
-| Feature | Test Files |
+| Requirement | Test Files |
 | --- | --- |
 | Update user data | rust-agent/src/main.rs (tests module `tests::it_runs`) |
 | Start data service | cpp-service/tests/test_dataservice.sh |
 | Activate Python worker | tests/test_worker.py |
+| Reliable sensor data roundtrip | tests/test_worker.py::test_sensor_reading_pub_sub_roundtrip |
+
+The sensor roundtrip test polls ZeroMQ sockets instead of using time-based delays,
+demonstrating that messages arrive without relying on arbitrary sleeps.

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -54,7 +54,6 @@ def test_process_parses_event_and_sends_request():
 
 
 def test_sensor_reading_pub_sub_roundtrip():
-    import time
     import zmq
 
     from python_worker import worker
@@ -62,15 +61,19 @@ def test_sensor_reading_pub_sub_roundtrip():
     ctx = zmq.Context()
     pub_socket, sub_socket = worker.setup_sensor_pubsub(ctx, "inproc://sensor-test")
     reading = data_pb2.SensorReading(sensor_id=7, value=1.23, timestamp=99)
+
     poller = zmq.Poller()
     poller.register(pub_socket, zmq.POLLOUT)
-    end_time = time.time() + 1
-    while time.time() < end_time:
-        if poller.poll(50):
-            break
-    else:
+    if not poller.poll(1000):
         raise TimeoutError("subscriber handshake timed out")
+
     worker.send_sensor_reading(pub_socket, reading)
+
+    poller = zmq.Poller()
+    poller.register(sub_socket, zmq.POLLIN)
+    if not poller.poll(1000):
+        raise TimeoutError("no sensor reading received")
+
     received = worker.recv_sensor_reading(sub_socket)
     assert received == reading
 


### PR DESCRIPTION
## Summary
- replace time-based waits in worker test with ZeroMQ polling for handshake and message arrival
- document sensor roundtrip test in traceability matrix

## Testing
- `black tests/test_worker.py`
- `flake8 tests/test_worker.py` *(fails: command not found)*
- `pre-commit run --files tests/test_worker.py docs/traceability.md` *(fails: command not found)*
- `make test` *(fails: The following required packages were not found: libzmq)*

------
https://chatgpt.com/codex/tasks/task_e_689e766b9064832ab3baeec660991634