### PR TITLE
test: add ctest for data service

### DIFF
--- a/cpp-service/CMakeLists.txt
+++ b/cpp-service/CMakeLists.txt
@@ -17,3 +17,6 @@ add_executable(data_service DataService.cpp Cache.cpp Database.cpp)
 target_include_directories(data_service PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
 target_include_directories(data_service PRIVATE ${ZMQ_INCLUDE_DIRS})
 target_link_libraries(data_service PRIVATE sqlite3 ${ZMQ_LIBRARIES})
+
+enable_testing()
+add_test(NAME data_service COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/tests/test_dataservice.sh)

--- a/cpp-service/tests/test_dataservice.sh
+++ b/cpp-service/tests/test_dataservice.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+set -euo pipefail
+pytest "$(dirname "$0")/test_dataservice.py"


### PR DESCRIPTION
## Summary
- enable CTest and register data service test
- add shell wrapper to run existing Python data service test

## Testing
- `make lint` *(fails: pre-commit: No such file or directory)*
- `make test` *(fails: libzmq missing in CMake configuration)*
- `ctest --test-dir build/cpp-service` *(fails: No tests were found)*

------
https://chatgpt.com/codex/tasks/task_e_689f34b2a930832a9ae2d764f37d8b1b