### PR TITLE
build: add apt mirror fallback for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,12 @@ jobs:
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main universe multiverse restricted
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-security main universe multiverse restricted
           EOF
-          sudo apt-get update
+          sudo rm -rf /var/lib/apt/lists/*
+          if ! sudo apt-get update -o Acquire::Retries=3; then
+            sed -e 's@http://.*.ubuntu.com@http://azure.archive.ubuntu.com@' \
+                /etc/apt/sources.list | sudo tee /etc/apt/sources.list
+            sudo apt-get update
+          fi
       - name: Install dependencies
         run: |
           sudo apt-get install -y \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Enable arm64 packages
         run: |
           sudo dpkg --add-architecture arm64
+          sudo sed -i 's/^deb http/deb [arch=amd64] http/' /etc/apt/sources.list
           sudo tee /etc/apt/sources.list.d/arm64.list >/dev/null <<'EOF'
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble main universe multiverse restricted
           deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports noble-updates main universe multiverse restricted
@@ -24,8 +25,7 @@ jobs:
           EOF
           sudo rm -rf /var/lib/apt/lists/*
           if ! sudo apt-get update -o Acquire::Retries=3; then
-            sed -e 's@http://.*.ubuntu.com@http://azure.archive.ubuntu.com@' \
-                /etc/apt/sources.list | sudo tee /etc/apt/sources.list
+            sudo sed -i 's@http://.*.ubuntu.com@http://azure.archive.ubuntu.com@' /etc/apt/sources.list
             sudo apt-get update
           fi
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- clear stale apt lists before updating
- retry apt update and switch to Azure mirror on failure

## Testing
- `make lint` *(fails: pre-commit: No such file or directory)*
- `make test` *(fails: libzmq package not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f3a3e5d30832a88f82993812fb5c1