### PR TITLE
build: update libzmq packages in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,18 @@ jobs:
           sudo apt-get install -y \
             curl cmake libprotobuf-dev protobuf-compiler \
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format \
-            libzmq3-dev libsqlite3-dev pkg-config \
-            libzmq3-dev:arm64 libsqlite3-dev:arm64 \
+            libzmq5-dev libsqlite3-dev pkg-config \
+            libzmq5-dev:arm64 libsqlite3-dev:arm64 \
             qemu-user qemu-user-static qemu-system-aarch64
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           rustup target add aarch64-unknown-linux-gnu
           rustup component add clippy rustfmt
           pip install pytest pytest-cov pre-commit pyzmq protobuf behave
+      - name: Verify libzmq pkg-config
+        run: |
+          pkg-config --exists libzmq
+          PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig pkg-config --exists libzmq
       - name: Pre-commit
         run: pre-commit run --all-files
       - name: Build


### PR DESCRIPTION
## Summary
- use libzmq5 packages for amd64 and arm64 in CI
- check pkg-config can locate libzmq for both architectures

## Testing
- `pkg-config --exists libzmq && echo yes || echo no`
- `PKG_CONFIG_LIBDIR=/usr/lib/aarch64-linux-gnu/pkgconfig pkg-config --exists libzmq && echo yes || echo no`
- `make setup`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689f4124ce84832aa740fa70394994ce