### PR TITLE
ci: add arm64 protobuf packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,15 @@ jobs:
             curl cmake libprotobuf-dev protobuf-compiler \
             gcc-aarch64-linux-gnu g++-aarch64-linux-gnu python3-pip clang-format \
             libzmq3-dev libsqlite3-dev pkg-config \
-            libzmq3-dev:arm64 libsqlite3-dev:arm64 \
+            libzmq3-dev:arm64 libsqlite3-dev:arm64 libprotobuf-dev:arm64 protobuf-compiler:arm64 \
             qemu-user qemu-user-static qemu-system-aarch64
           curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
           echo "$HOME/.cargo/bin" >> $GITHUB_PATH
           rustup target add aarch64-unknown-linux-gnu
           rustup component add clippy rustfmt
           pip install pytest pytest-cov pre-commit pyzmq protobuf behave
+      - name: Verify protobuf pkg-config
+        run: PKG_CONFIG_PATH=/usr/lib/aarch64-linux-gnu/pkgconfig pkg-config --exists protobuf
       - name: Pre-commit
         run: pre-commit run --all-files
       - name: Build


### PR DESCRIPTION
## Summary
- install arm64 protobuf packages in CI and check pkg-config availability

## Testing
- `make lint` *(fails: pre-commit: No such file or directory)*
- `make test` *(fails: required packages libzmq not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f41262568832a8e099b27f02ade62